### PR TITLE
Enable github token in auto-update workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -12,8 +12,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Nix
         uses: cachix/install-nix-action@v16
-        # with:
-        #   extra_nix_config: |
-        #     access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v3


### PR DESCRIPTION
I think this _might_ fix the issue where ci is not running on auto-update PRs?

See https://github.com/nix-community/nix-eval-jobs/pull/22.