### PR TITLE
Flush cout after each output line

### DIFF
--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -404,7 +404,7 @@ int main(int argc, char * * argv)
                         }
                     } else {
                         auto state(state_.lock());
-                        std::cout << respString << "\n";
+                        std::cout << respString << "\n" << std::flush;
                     }
 
                     /* Add newly discovered job names to the queue. */


### PR DESCRIPTION
The default buffering behavior depends on whether the output is connected to an interactive device. This causes output lines to be buffered in an undesirable way when stdout is piped, which is how nix-eval-jobs is normally used. Let's fix it by flushing stdout explicitly.

You can reproduce the issue with the expression below. Try the following from an interactive terminal:

1. `nix-eval-jobs buffer-repro.nix`
2. `nix-eval-jobs buffer-repro.nix | cat`
3. `stdbuf -oL nix-eval-jobs buffer-repro.nix | cat`
4. Apply the patch, then `nix-eval-jobs buffer-repro.nix | cat`

## `buffer-repro.nix`

```nix
let
  nixpkgs = builtins.fetchTarball {
    url = "https://github.com/NixOS/nixpkgs/archive/554d2d8aa25b6e583575459c297ec23750adb6cb.tar.gz";
    sha256 = "01yfqslnkyrfb5yjfablhvw830iw0za3mab4n03a0ldyq5ac6wh1";
  };
  pkgs = import nixpkgs {};
in {
  fast = pkgs.hello;

  slow = let
    config = { pkgs, lib, ... }: {
      containers = let
        l = map (name: lib.nameValuePair name {
          config = {
            services.redis.enable = true;
          };
        }) [ "a" "b" "c" "d" ];
      in builtins.listToAttrs l;

      boot.loader.grub.enable = false;
      fileSystems."/".device = "fake";
    };
    eval = pkgs.nixos config;
  in eval.config.system.build.toplevel;
}
```

## Interactive - No Problem

```terminal
$ ./build/src/nix-eval-jobs buffer-repro.nix
warning: `--gc-roots-dir' not specified
{"attr":"fast","drvPath":"/nix/store/880m2s76cxsg2lg6hrlnfn0khazd1xz1-hello-2.12.drv","name":"hello-2.12","outputs":{"out":"/nix/store/2a1m8qmdafvmshm93236q3sz3rhrjd9f-hello-2.12"},"system":"x86_64-linux"}
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
{"attr":"slow","drvPath":"/nix/store/rk5lpn8kickn8rympxdkkxij8706cj5l-nixos-system-nixos-22.05pre-git.drv","name":"nixos-system-nixos-22.05pre-git","outputs":{"out":"/nix/store/bzykyygnvh34fj2416mj50njp38drhx0-nixos-system-nixos-22.05pre-git"},"system":"x86_64-linux"}
```

## Piped - Before

```terminal
$ ./build/src/nix-eval-jobs buffer-repro.nix | cat
warning: `--gc-roots-dir' not specified
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
{"attr":"fast","drvPath":"/nix/store/880m2s76cxsg2lg6hrlnfn0khazd1xz1-hello-2.12.drv","name":"hello-2.12","outputs":{"out":"/nix/store/2a1m8qmdafvmshm93236q3sz3rhrjd9f-hello-2.12"},"system":"x86_64-linux"}
{"attr":"slow","drvPath":"/nix/store/rk5lpn8kickn8rympxdkkxij8706cj5l-nixos-system-nixos-22.05pre-git.drv","name":"nixos-system-nixos-22.05pre-git","outputs":{"out":"/nix/store/bzykyygnvh34fj2416mj50njp38drhx0-nixos-system-nixos-22.05pre-git"},"system":"x86_64-linux"}
```

## Piped - After

```terminal
$ ./build/src/nix-eval-jobs buffer-repro.nix | cat
warning: `--gc-roots-dir' not specified
{"attr":"fast","drvPath":"/nix/store/880m2s76cxsg2lg6hrlnfn0khazd1xz1-hello-2.12.drv","name":"hello-2.12","outputs":{"out":"/nix/store/2a1m8qmdafvmshm93236q3sz3rhrjd9f-hello-2.12"},"system":"x86_64-linux"}
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
trace: warning: The option `services.redis.enable' defined in `<unknown-file>' has been renamed to `services.redis.servers..enable'.
{"attr":"slow","drvPath":"/nix/store/rk5lpn8kickn8rympxdkkxij8706cj5l-nixos-system-nixos-22.05pre-git.drv","name":"nixos-system-nixos-22.05pre-git","outputs":{"out":"/nix/store/bzykyygnvh34fj2416mj50njp38drhx0-nixos-system-nixos-22.05pre-git"},"system":"x86_64-linux"}
```