### PR TITLE
Remove hydra-specific restrictions on attribute names.

### DIFF
--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -234,12 +234,7 @@ static void worker(
                 auto attrs = nlohmann::json::array();
                 StringSet ss;
                 for (auto & i : v->attrs->lexicographicOrder()) {
-                    std::string name(i->name);
-                    if (name.find('.') != std::string::npos || name.find(' ') != std::string::npos) {
-                        printError("skipping job with illegal name '%s'", name);
-                        continue;
-                    }
-                    attrs.push_back(name);
+                    attrs.push_back(i->name);
                 }
                 reply["attrs"] = std::move(attrs);
             }

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -1,6 +1,7 @@
 #include <map>
 #include <iostream>
 #include <thread>
+#include <sstream>
 
 #include <nix/config.h>
 #include <nix/shared.hh>
@@ -234,7 +235,9 @@ static void worker(
                 auto attrs = nlohmann::json::array();
                 StringSet ss;
                 for (auto & i : v->attrs->lexicographicOrder()) {
-                    attrs.push_back(i->name);
+                    std::ostringstream s;
+                    s << "\"" << i->name << "\"";
+                    attrs.push_back(s.str());
                 }
                 reply["attrs"] = std::move(attrs);
             }


### PR DESCRIPTION
At least I think that's why these name restrictions exist.