### PR TITLE
Set GC_DONT_GC=1.

### DIFF
--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -282,6 +282,9 @@ int main(int argc, char * * argv)
        $NIX_PATH. */
     unsetenv("NIX_PATH");
 
+    /* We are doing the garbage collection by killing forks */
+    setenv("GC_DONT_GC", "1", 1);
+
     return handleExceptions(argv[0], [&]() {
         initNix();
         initGC();


### PR DESCRIPTION
To avoid `Collecting from unknown thread`.  I think this is a reasonable change, since `nix-eval-jobs`' hack is to basically replace the nix garbage collector with the operating system.

Closes #47 