### PR TITLE
Add debug symbols to nix-shell.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -32,4 +32,7 @@
 
   ];
 
+  shellHook = ''
+    export NIX_DEBUG_INFO_DIRS="${pkgs.curl.debug}/lib/debug:${pkgs.nixUnstable.debug}/lib/debug''${NIX_DEBUG_INFO_DIRS:+:$NIX_DEBUG_INFO_DIRS}"
+  '';
 })

--- a/shell.nix
+++ b/shell.nix
@@ -13,9 +13,13 @@
 , srcDir ? null
 }:
 
-(pkgs.callPackage ./default.nix {
-  inherit srcDir;
+let
+  inherit (pkgs) lib stdenv;
   nix = pkgs.nixUnstable;
+
+in
+(pkgs.callPackage ./default.nix {
+  inherit nix srcDir;
 }).overrideAttrs (old: {
 
   src = null;
@@ -32,7 +36,7 @@
 
   ];
 
-  shellHook = ''
-    export NIX_DEBUG_INFO_DIRS="${pkgs.curl.debug}/lib/debug:${pkgs.nixUnstable.debug}/lib/debug''${NIX_DEBUG_INFO_DIRS:+:$NIX_DEBUG_INFO_DIRS}"
+  shellHook = lib.optionalString stdenv.isLinux ''
+    export NIX_DEBUG_INFO_DIRS="${pkgs.curl.debug}/lib/debug:${nix.debug}/lib/debug''${NIX_DEBUG_INFO_DIRS:+:$NIX_DEBUG_INFO_DIRS}"
   '';
 })


### PR DESCRIPTION
I found debugging in gdb critical when debugging some issues.