### PR TITLE
Add test for a job with a nested attrset

### DIFF
--- a/tests/assets/ci.nix
+++ b/tests/assets/ci.nix
@@ -1,7 +1,9 @@
-let
-  pkgs = import (builtins.getFlake (toString ./.)).inputs.nixpkgs { };
-in
+{ pkgs ? import (builtins.getFlake (toString ./.)).inputs.nixpkgs { } }:
+
 {
   builtJob = pkgs.writeText "job1" "job1";
   substitutedJob = pkgs.hello;
+  nested = {
+    job = pkgs.hello;
+  };
 }

--- a/tests/assets/flake.nix
+++ b/tests/assets/flake.nix
@@ -6,9 +6,6 @@
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
     in
     {
-      hydraJobs = {
-        builtJob = pkgs.writeText "job1" "job1";
-        substitutedJob = pkgs.hello;
-      };
+      hydraJobs = import ./ci.nix { inherit pkgs; };
     };
 }

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -23,7 +23,7 @@ def common_test(extra_args: List[str]) -> None:
         )
 
         results = [json.loads(r) for r in res.stdout.split("\n") if r]
-        assert len(results) == 2
+        assert len(results) == 3
 
         built_job = results[0]
         assert built_job["attr"] == "builtJob"
@@ -32,7 +32,11 @@ def common_test(extra_args: List[str]) -> None:
         assert built_job["drvPath"].endswith(".drv")
         assert built_job["meta"]['broken'] is False
 
-        substituted_job = results[1]
+        nested_job = results[1]
+        assert nested_job["attr"] == "nested.job"
+        assert nested_job["name"].startswith("hello-")
+
+        substituted_job = results[2]
         assert substituted_job["attr"] == "substitutedJob"
         assert substituted_job["name"].startswith("hello-")
         assert substituted_job["meta"]['broken'] is False


### PR DESCRIPTION
I noticed that this was broken in https://github.com/nix-community/nix-eval-jobs/pull/43 but was not tested.