### PR TITLE
Add support for recurseForDerivations

### DIFF
--- a/tests/assets/ci.nix
+++ b/tests/assets/ci.nix
@@ -1,9 +1,34 @@
-{ pkgs ? import (builtins.getFlake (toString ./.)).inputs.nixpkgs { } }:
+{
+  pkgs ? import (builtins.getFlake (toString ./.)).inputs.nixpkgs { }
+  , system ? pkgs.system
+}:
 
 {
   builtJob = pkgs.writeText "job1" "job1";
   substitutedJob = pkgs.hello;
-  nested = {
-    job = pkgs.hello;
+
+  dontRecurse = {
+    # This shouldn't build as `recurseForDerivations = true;` is not set
+    # recurseForDerivations = true;
+
+    # This should not build
+    drvB = derivation {
+      inherit system;
+      name = "drvA";
+      builder = ":";
+    };
   };
+
+  recurse = {
+    # This should build
+    recurseForDerivations = true;
+
+    # This should not build
+    drvB = derivation {
+      inherit system;
+      name = "drvB";
+      builder = ":";
+    };
+  };
+
 }

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -23,7 +23,7 @@ def common_test(extra_args: List[str]) -> None:
         )
 
         results = [json.loads(r) for r in res.stdout.split("\n") if r]
-        assert len(results) == 3
+        assert len(results) == 4
 
         built_job = results[0]
         assert built_job["attr"] == "builtJob"
@@ -32,11 +32,14 @@ def common_test(extra_args: List[str]) -> None:
         assert built_job["drvPath"].endswith(".drv")
         assert built_job["meta"]['broken'] is False
 
-        nested_job = results[1]
-        assert nested_job["attr"] == "nested.job"
-        assert nested_job["name"].startswith("hello-")
+        recurse_drv = results[1]
+        assert recurse_drv["attr"] == "recurse.drvB"
+        assert recurse_drv["name"] == "drvB"
 
-        substituted_job = results[2]
+        recurse_recurse_bool = results[2]
+        assert "error" in recurse_recurse_bool
+
+        substituted_job = results[3]
         assert substituted_job["attr"] == "substitutedJob"
         assert substituted_job["name"].startswith("hello-")
         assert substituted_job["meta"]['broken'] is False


### PR DESCRIPTION
This will respect `recurseForDerivations` when iterating over attrsets.

Example expression:
``` nix
{ system ? builtins.currentSystem }:
{
  # This should build as it's in the top level attrset
  topDrv = derivation {
    inherit system;
    name = "drvTop";
    builder = ":";
  };

  # This should build
  drvA = derivation {
    inherit system;
    name = "drvA";
    builder = ":";
  };

  recurse = {
    # Should build if this attribute exists
    # recurseForDerivations = true;

    # This should not build
    drvB = derivation {
      inherit system;
      name = "drvA";
      builder = ":";
    };
  };
}
```

Closes #9 