### PR TITLE
Replace internal attr string representation with an array

### DIFF
--- a/tests/assets/ci.nix
+++ b/tests/assets/ci.nix
@@ -31,4 +31,6 @@
     };
   };
 
+  "dotted.attr" = pkgs.hello;
+
 }

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -23,7 +23,7 @@ def common_test(extra_args: List[str]) -> None:
         )
 
         results = [json.loads(r) for r in res.stdout.split("\n") if r]
-        assert len(results) == 4
+        assert len(results) == 5
 
         built_job = results[0]
         assert built_job["attr"] == "builtJob"
@@ -32,14 +32,18 @@ def common_test(extra_args: List[str]) -> None:
         assert built_job["drvPath"].endswith(".drv")
         assert built_job["meta"]['broken'] is False
 
-        recurse_drv = results[1]
+        dotted_job = results[1]
+        assert dotted_job["attr"] == "\"dotted.attr\""
+        assert dotted_job["attrPath"] == [ "dotted.attr" ]
+
+        recurse_drv = results[2]
         assert recurse_drv["attr"] == "recurse.drvB"
         assert recurse_drv["name"] == "drvB"
 
-        recurse_recurse_bool = results[2]
+        recurse_recurse_bool = results[3]
         assert "error" in recurse_recurse_bool
 
-        substituted_job = results[3]
+        substituted_job = results[4]
         assert substituted_job["attr"] == "substitutedJob"
         assert substituted_job["name"].startswith("hello-")
         assert substituted_job["meta"]['broken'] is False


### PR DESCRIPTION
This ensures correct handling of attrnames with a dot in them and will
not throw errors about illegal attrnames.

Additionally this escapes any attributes containing dots in the JSON
output and adds another field called `attrPath` which contains the
attribute path as a list.

Example output:
``` json
{
  "attr": "hello",
  "attrPath": [
    "hello"
  ],
  "drvPath": "/nix/store/n204jib73z55cp9s0rmw1c5v5q528j7v-hello-2.12.drv",
  "name": "hello-2.12",
  "outputs": {
    "out": "/nix/store/h59dfk7dwrn7d2csykh9z9xm2miqmrnz-hello-2.12"
  },
  "system": "x86_64-linux"
}
```