### PR TITLE
Add support for passing a Nix expression on the command line

### DIFF
--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -55,3 +55,6 @@ def test_flake() -> None:
 
 def test_expression() -> None:
     common_test(["ci.nix"])
+
+    with open(TEST_ROOT.joinpath("assets/ci.nix"), "r") as ci_nix:
+        common_test(["-E", ci_nix.read()])


### PR DESCRIPTION
This PR adds support for passing a Nix expression on the command line (`--expr` / `-E`). It's done following the same semantics as in `nix-instantiate`, where `--expr` / `-E` is [a valueless flag](https://github.com/NixOS/nix/blob/af4e8b00fb986acf32d7e4cd4fff7218b38958df/src/nix-instantiate/nix-instantiate.cc#L185-L187) that causes the positional "file" arguments to be interpreted as Nix expressions rather than paths. Closes #38.

Also tacking on a small change to not touch `evalSettings.pureEval` unless `--impure` or `--flake` is specified. This allows eval flags like `--pure-eval` to be used.