### PR TITLE
Add flake --override-input

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: llvm
+IndentWidth: 4
+SortIncludes: false

--- a/default.nix
+++ b/default.nix
@@ -1,36 +1,31 @@
 { stdenv
 , lib
 , nix
-, meson
-, cmake
-, ninja
-, pkg-config
-, boost
-, nlohmann_json
+, pkgs
 , srcDir ? null
 }:
 
 let
-  filterMesonBuild = dir: builtins.filterSource
-    (path: type: type != "directory" || baseNameOf path != "build")
-    dir;
+  filterMesonBuild = builtins.filterSource
+    (path: type: type != "directory" || baseNameOf path != "build");
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "nix-eval-jobs";
   version = "2.16.0";
   src = if srcDir == null then filterMesonBuild ./. else srcDir;
-  buildInputs = [
+  buildInputs = with pkgs; [
     nlohmann_json
     nix
     boost
   ];
-  nativeBuildInputs = [
+  nativeBuildInputs = with pkgs; [
+    bear
     meson
     pkg-config
     ninja
     # nlohmann_json can be only discovered via cmake files
     cmake
-  ];
+  ] ++ (lib.optional stdenv.cc.isClang [ pkgs.bear pkgs.clang-tools ]);
 
   meta = {
     description = "Hydra's builtin hydra-eval-jobs as a standalone";

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
           in
           {
             packages.nix-eval-jobs = pkgs.callPackage ./default.nix drvArgs;
+            packages.clangStdenv-nix-eval-jobs = pkgs.callPackage ./default.nix (drvArgs // { stdenv = pkgs.clangStdenv; });
 
             checks.treefmt = pkgs.stdenv.mkDerivation {
               name = "treefmt-check";

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -54,12 +54,10 @@ struct MyArgs : MixEvalArgs, MixCommonArgs {
     size_t maxMemorySize = 4096;
 
     // usually in MixFlakeOptions
-    flake::LockFlags lockFlags = {
-        .updateLockFile = false,
-        .writeLockFile = false,
-        .useRegistries = false,
-        .allowUnlocked = false
-    };
+    flake::LockFlags lockFlags = {.updateLockFile = false,
+                                  .writeLockFile = false,
+                                  .useRegistries = false,
+                                  .allowUnlocked = false};
 
     MyArgs() : MixCommonArgs("nix-eval-jobs") {
         addFlag({
@@ -136,7 +134,8 @@ struct MyArgs : MixEvalArgs, MixCommonArgs {
         // usually in MixFlakeOptions
         addFlag({
             .longName = "override-input",
-            .description = "Override a specific flake input (e.g. `dwarffs/nixpkgs`).",
+            .description =
+                "Override a specific flake input (e.g. `dwarffs/nixpkgs`).",
             .category = category,
             .labels = {"input-path", "flake-url"},
             .handler = {[&](std::string inputPath, std::string flakeRef) {
@@ -284,12 +283,11 @@ static void worker(ref<EvalState> state, Bindings &autoArgs, AutoCloseFD &to,
     nix::Value *vRoot = [&]() {
         if (myArgs.flake) {
             auto [flakeRef, fragment, outputSpec] =
-                parseFlakeRefWithFragmentAndExtendedOutputsSpec(myArgs.releaseExpr,
-                                                                absPath("."));
-            InstallableFlake flake {
-                {}, state, std::move(flakeRef), fragment,
-                outputSpec, {}, {}, myArgs.lockFlags
-            };
+                parseFlakeRefWithFragmentAndExtendedOutputsSpec(
+                    myArgs.releaseExpr, absPath("."));
+            InstallableFlake flake{
+                {}, state, std::move(flakeRef), fragment, outputSpec,
+                {}, {},    myArgs.lockFlags};
 
             return flake.toValue(*state).first;
         } else {

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,10 +1,6 @@
 [formatter."c++"]
 command = "clang-format"
-options = [
-  "-i",
-  "-style",
-  "{BasedOnStyle: llvm, IndentWidth: 4, SortIncludes: false}"
-]
+options = ["-i"]
 includes = ["*.c", "*.cpp", "*.cc", "*.h", "*.hpp"]
 
 [formatter.nix]


### PR DESCRIPTION
This patch adds the `--override-input` flags as present in the nix CLI, closing #144.

A more complete implementation would have been adding `MixFlakeOptions` to `MyArgs` parents but I am not too familiar with the codebase and I opted for the simpler solution of adding the single flag.

I allowed myself to readjust the flake adding a derivation based on clangStdenv, but I can remove that commit from the PR if undesidered.

Thank you!