### PR TITLE
don't fail nix-eval-jobs on eval errors

### DIFF
--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -190,10 +190,6 @@ std::function<void()> collector(Sync<State> &state_,
                 json response;
                 try {
                     response = json::parse(respString);
-                    if (response.find("error") != response.end()) {
-                        throw Error("worker error: %s",
-                                    (std::string)response["error"]);
-                    }
                 } catch (const json::exception &e) {
                     throw Error("Received invalid JSON from worker: %s '%s'",
                                 e.what(), respString);


### PR DESCRIPTION
This error handling was copied by accident in https://github.com/nix-community/nix-eval-jobs/commit/5c764d4a67feceae1848414fd9434e79120884e6#diff-a79ded172fd76747492a417a39848b6c25c14238e65971e6a05fe81706d5048fR622