### PR TITLE
Enable Boehm memory garbage collection

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -31,4 +31,4 @@ executable('nix-eval-jobs', src,
              threads_dep
            ],
            install: true,
-           cpp_args: ['-std=c++2a', '-fvisibility=hidden', '--include', 'autotools-config.h'])
+           cpp_args: ['-std=c++2a', '-fvisibility=hidden', '--include', 'autotools-config.h', '-DGC_THREADS'])

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -300,6 +300,7 @@ int main(int argc, char **argv) {
     return handleExceptions(argv[0], [&]() {
         initNix();
         initGC();
+        GC_allow_register_threads();
 
         myArgs.parseArgs(argv, argc);
 


### PR DESCRIPTION
Nix uses the conservative memory garbage collector Boehm, however this was previously explicitly [disabled in nix-eval-jobs][disabled-gc]:

```
/* We are doing the garbage collection by killing forks */
setenv("GC_DONT_GC", "1", 1);
```

The [commit message for this change][disabled-gc-commit] suggests that it wasn't an intentional decision to disable GC, but instead a workaround to resolve Boehm not knowing about the threads nix-eval-jobs was using and printing "Collecting from unknown thread" messages.

This PR explicitly registers the worker threads with Boehm, which resolves the original issue.

By enabling memory garbage collection, workers will use less peak memory during evaluation allowing them to live longer and re-use a larger number of prior evaluations prior to being reaped.

[disabled-gc]: https://github.com/nix-community/nix-eval-jobs/blob/main/src/nix-eval-jobs.cc#L296-L297
[disabled-gc-commit]: https://github.com/nix-community/nix-eval-jobs/commit/b062ac705df9d5b5040ce35c8c01cda394cd8a2a