### PR TITLE
fix: cacheStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you provide the `--check-cache-status`, the json will contain a
 | -------- | ------------------------------------------------------- |
 | local    | Package is present locally                              |
 | cached   | Package is present in the binary cache, but not locally |
-| notBuild | Package needs to be build.                              |
+| notBuilt | Package needs to be built.                              |
 
 ### How can I evaluate nixpkgs?
 

--- a/src/drv.cc
+++ b/src/drv.cc
@@ -37,11 +37,19 @@ queryCacheStatus(nix::Store &store,
     store.queryMissing(toDerivedPaths(paths), willBuild, willSubstitute,
                        unknown, downloadSize, narSize);
     if (willBuild.empty() && unknown.empty()) {
-        return Drv::CacheStatus::NotBuild;
-    } else if (willSubstitute.empty()) {
-        return Drv::CacheStatus::Local;
+        if (willSubstitute.empty()) {
+            // cacheStatus is Local if:
+            //  - there's nothing to build
+            //  - there's nothing to substitute
+            return Drv::CacheStatus::Local;
+        } else {
+            // cacheStatus is Cached if:
+            //  - there's nothing to build
+            //  - there are paths to substitute
+            return Drv::CacheStatus::Cached;
+        }
     } else {
-        return Drv::CacheStatus::Cached;
+        return Drv::CacheStatus::NotBuilt;
     }
 }
 
@@ -123,6 +131,6 @@ void to_json(nlohmann::json &json, const Drv &drv) {
         json["cacheStatus"] =
             drv.cacheStatus == Drv::CacheStatus::Cached  ? "cached"
             : drv.cacheStatus == Drv::CacheStatus::Local ? "local"
-                                                         : "notBuild";
+                                                         : "notBuilt";
     }
 }

--- a/src/drv.hh
+++ b/src/drv.hh
@@ -23,7 +23,7 @@ struct Drv {
     std::string system;
     std::string drvPath;
 
-    enum class CacheStatus { Local, Cached, NotBuild, Unknown } cacheStatus;
+    enum class CacheStatus { Local, Cached, NotBuilt, Unknown } cacheStatus;
     std::map<std::string, std::string> outputs;
     std::map<std::string, std::set<std::string>> inputDrvs;
     std::optional<nlohmann::json> meta;


### PR DESCRIPTION
- fixes the regression introduced in https://github.com/nix-community/nix-eval-jobs/pull/304


I also took the chance to fix the spelling of `notBuild` to `notBuilt` (I suspect this is not a breaking change since `nix-eval-jobs` hasn't been released since, and the release would have been broken anyway)