### PR TITLE
feat: add `--apply` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ executable.
 $ nix-eval-jobs --help
 USAGE: nix-eval-jobs [options] expr
 
+  --apply                apply the derivation to the provided Nix expression
   --arg                  Pass the value *expr* as the argument *name* to Nix functions.
   --argstr               Pass the string *string* as the argument *name* to Nix functions.
   --check-cache-status   Check if the derivations are present locally or in any configured substituters (i.e. binary cache). The information will be exposed in the `cacheStatus` field of the JSON output.

--- a/src/eval-args.cc
+++ b/src/eval-args.cc
@@ -102,6 +102,12 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
              .description = "treat the argument as a Nix expression",
              .handler = {&fromArgs, true}});
 
+    addFlag(
+        {.longName = "apply",
+         .description = "apply the derivation to the provided Nix expression",
+         .labels = {"expr"},
+         .handler = {&applyExpr}});
+
     // usually in MixFlakeOptions
     addFlag({
         .longName = "override-input",

--- a/src/eval-args.hh
+++ b/src/eval-args.hh
@@ -14,6 +14,7 @@ class MyArgs : virtual public nix::MixEvalArgs,
   public:
     virtual ~MyArgs() = default;
     std::string releaseExpr;
+    std::string applyExpr;
     nix::Path gcRootsDir;
     bool flake = false;
     bool fromArgs = false;

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -205,7 +205,9 @@ void worker(
                         }
                         maybeConstituents =
                             Constituents(constituents, namedConstituents);
-                    } else if (args.applyExpr != "") {
+                    }
+
+                    if (args.applyExpr != "") {
                         auto applyExpr = state->parseExprFromString(
                             args.applyExpr, state->rootPath("."));
 
@@ -226,6 +228,7 @@ void worker(
 
                         reply.update(nlohmann::json::parse(ss.str()));
                     }
+
                     auto drv = Drv(attrPathS, *state, *packageInfo, args,
                                    maybeConstituents);
                     reply.update(drv);


### PR DESCRIPTION
Allow applying every eval'ed drv to a provided nix expression to evaluate arbitrary fields.

EXAMPLE

```
% ./result/bin/nix-eval-jobs --flake github:NixOS/patchelf#hydraJobs \
  --apply \
  'drv: {
     version = if drv ? version then drv.version else null;
   }'
warning: `--gc-roots-dir' not specified
{"attr":"coverage","attrPath":["coverage"],"version":null}
{"attr":"patchelf-win32","attrPath":["patchelf-win32"],"version":"0.18.0"}
{"attr":"patchelf-win64","attrPath":["patchelf-win64"],"version":"0.18.0"}
{"attr":"release","attrPath":["release"],"version":null}
{"attr":"tarball","attrPath":["tarball"],"version":"0.18.0"}
```