### PR TITLE
Passthrough `nix`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation {
     ]
     ++ (lib.optional stdenv.cc.isClang [ pkgs.clang-tools ]);
 
+  passthru.nix = nix;
   meta = {
     description = "Hydra's builtin hydra-eval-jobs as a standalone";
     homepage = "https://github.com/nix-community/nix-eval-jobs";


### PR DESCRIPTION
Allows for passing the git version of `n-e-j` into `n-f-b` like so:
```nix
(pkgs.callPackage inputs.nix-fast-build.packages.${pkgs.stdenv.system}.nix-fast-build.override {
  nix-eval-jobs = inputs.nix-eval-jobs.packages.${pkgs.stdenv.system}.nix-eval-jobs;
})
```