### PR TITLE
Bring back constituents to Hydra

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
             "nscloud-cache-size-20gb"
             "nscloud-cache-tag-nix-eval-jobs"
           ];
-          "x86_64-darwin" = "macos-12";
+          "x86_64-darwin" = "macos-13";
           "aarch64-darwin" = "macos-14";
           "aarch64-linux" = [
             "nscloud-ubuntu-22.04-arm64-4x16-with-cache"

--- a/src/drv.cc
+++ b/src/drv.cc
@@ -67,7 +67,9 @@ auto queryCacheStatus(nix::Store &store,
 
 /* The fields of a derivation that are printed in json form */
 Drv::Drv(std::string &attrPath, nix::EvalState &state,
-         nix::PackageInfo &packageInfo, MyArgs &args) {
+         nix::PackageInfo &packageInfo, MyArgs &args,
+         std::optional<Constituents> constituents)
+    : constituents(constituents) {
 
     auto localStore = state.store.dynamic_pointer_cast<nix::LocalFSStore>();
 
@@ -175,6 +177,11 @@ void to_json(nlohmann::json &json, const Drv &drv) {
 
     if (drv.meta.has_value()) {
         json["meta"] = drv.meta.value();
+    }
+
+    if (auto constituents = drv.constituents) {
+        json["constituents"] = constituents->constituents;
+        json["namedConstituents"] = constituents->namedConstituents;
     }
 
     if (drv.cacheStatus != Drv::CacheStatus::Unknown) {

--- a/src/drv.hh
+++ b/src/drv.hh
@@ -14,10 +14,19 @@ class EvalState;
 struct PackageInfo;
 } // namespace nix
 
+struct Constituents {
+    std::vector<std::string> constituents;
+    std::vector<std::string> namedConstituents;
+    Constituents(std::vector<std::string> constituents,
+                 std::vector<std::string> namedConstituents)
+        : constituents(constituents), namedConstituents(namedConstituents) {};
+};
+
 /* The fields of a derivation that are printed in json form */
 struct Drv {
     Drv(std::string &attrPath, nix::EvalState &state,
-        nix::PackageInfo &packageInfo, MyArgs &args);
+        nix::PackageInfo &packageInfo, MyArgs &args,
+        std::optional<Constituents> constituents);
     std::string name;
     std::string system;
     std::string drvPath;
@@ -31,5 +40,6 @@ struct Drv {
     std::map<std::string, std::optional<std::string>> outputs;
     std::map<std::string, std::set<std::string>> inputDrvs;
     std::optional<nlohmann::json> meta;
+    std::optional<Constituents> constituents;
 };
 void to_json(nlohmann::json &json, const Drv &drv);

--- a/src/eval-args.cc
+++ b/src/eval-args.cc
@@ -71,6 +71,12 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
              .handler = {&meta, true}});
 
     addFlag(
+        {.longName = "constituents",
+         .description =
+             "whether to evaluate constituents for Hydra's aggregate feature",
+         .handler = {&constituents, true}});
+
+    addFlag(
         {.longName = "check-cache-status",
          .description =
              "Check if the derivations are present locally or in "

--- a/src/eval-args.hh
+++ b/src/eval-args.hh
@@ -22,6 +22,7 @@ class MyArgs : virtual public nix::MixEvalArgs,
     bool impure = false;
     bool forceRecurse = false;
     bool checkCacheStatus = false;
+    bool constituents = false;
     size_t nrWorkers = 1;
     size_t maxMemorySize = 4096;
 

--- a/tests/assets/flake.nix
+++ b/tests/assets/flake.nix
@@ -2,7 +2,7 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
   outputs =
-    { nixpkgs, ... }:
+    { self, nixpkgs, ... }:
     let
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
     in
@@ -24,6 +24,36 @@
               recursiveAttr = recursion;
               builder = ":";
             };
+        };
+        success = {
+          aggregate =
+            pkgs.runCommand "aggregate"
+              {
+                _hydraAggregate = true;
+                constituents = [
+                  self.hydraJobs.builtJob
+                  "anotherone"
+                ];
+              }
+              ''
+                touch $out
+              '';
+          anotherone = pkgs.writeText "constituent" "text";
+        };
+        failures = {
+          aggregate =
+            pkgs.runCommand "aggregate"
+              {
+                _hydraAggregate = true;
+                constituents = [
+                  "doesntexist"
+                  "doesnteval"
+                ];
+              }
+              ''
+                touch $out
+              '';
+          doesnteval = pkgs.writeText "constituent" (toString { });
         };
       };
     };


### PR DESCRIPTION
This is a commit from @ma27 https://git.lix.systems/ma27/nix-eval-jobs/commit/5ce92e2c4d318b30edaafa4d8664b9e15e941f32 I rebased. Thanks @ma27!

This (or something like it) is needed for `nix-eval-jobs` to replace `hydra-eval-jobs`.

----------

The part about finding `_hydraAggregate`/`constituents` is basically derived from `hydra-eval-jobs`, however the part about `namedConstituents` has been changed: we still stream out jobs when they appear, however we suppress this for aggregate jobs.

These jobs are post-processed at the end, i.e. if `namedConstituents` exist, these will be mapped to the drvPath of the other jobs. Then, the drv will be rewritten to contain the drvPath of said jobs[1] and the JSON containing the rewritten `drvPath` will be printed out.

[1] This was an optimization to reduce the memory footprint of
    evaluating e.g. the `tested` job in nixpkgs.

(cherry picked from commit 76f32ed29e25b22d69467d28b72efcc9ac22e1bf)