### PR TITLE
Implement constituent globs

### DIFF
--- a/src/constituents.cc
+++ b/src/constituents.cc
@@ -1,0 +1,224 @@
+#include <fnmatch.h>
+#include <nlohmann/json.hpp>
+#include <nix/config.h>
+#include <nix/derivations.hh>
+#include <nix/local-fs-store.hh>
+
+#include "constituents.hh"
+
+namespace {
+// This is copied from `libutil/topo-sort.hh` in CppNix and slightly modified.
+// However, I needed a way to use strings as identifiers to sort, but still be
+// able to put AggregateJob objects into this function since I'd rather not have
+// to transform back and forth between a list of strings and AggregateJobs in
+// resolveNamedConstituents.
+auto topoSort(const std::set<AggregateJob> &items)
+    -> std::vector<AggregateJob> {
+    std::vector<AggregateJob> sorted;
+    std::set<std::string> visited;
+    std::set<std::string> parents;
+
+    std::map<std::string, AggregateJob> dictIdentToObject;
+    for (const auto &it : items) {
+        dictIdentToObject.insert({it.name, it});
+    }
+
+    std::function<void(const std::string &path, const std::string *parent)>
+        dfsVisit;
+
+    dfsVisit = [&](const std::string &path, const std::string *parent) {
+        if (parents.contains(path)) {
+            dictIdentToObject.erase(path);
+            dictIdentToObject.erase(*parent);
+            std::set<std::string> remaining;
+            for (auto &[k, _] : dictIdentToObject) {
+                remaining.insert(k);
+            }
+            throw DependencyCycle(path, *parent, remaining);
+        }
+
+        if (!visited.insert(path).second) {
+            return;
+        }
+        parents.insert(path);
+
+        std::set<std::string> references = dictIdentToObject[path].dependencies;
+
+        for (const auto &i : references) {
+            /* Don't traverse into items that don't exist in our starting set.
+             */
+            if (i != path &&
+                dictIdentToObject.find(i) != dictIdentToObject.end()) {
+                dfsVisit(i, &path);
+            }
+        }
+
+        sorted.push_back(dictIdentToObject[path]);
+        parents.erase(path);
+    };
+
+    for (auto &[i, _] : dictIdentToObject) {
+        dfsVisit(i, nullptr);
+    }
+
+    return sorted;
+}
+
+auto insertMatchingConstituents(
+    const std::string &childJobName, const std::string &jobName,
+    const std::function<bool(const std::string &, const nlohmann::json &)>
+        &isBroken,
+    const std::map<std::string, nlohmann::json> &jobs,
+    std::set<std::string> &results) -> bool {
+    bool expansionFound = false;
+    for (const auto &[currentJobName, job] : jobs) {
+        // Never select the job itself as constituent. Trivial way
+        // to avoid obvious cycles.
+        if (currentJobName == jobName) {
+            continue;
+        }
+        auto jobName = currentJobName;
+        if (fnmatch(childJobName.c_str(), jobName.c_str(), 0) == 0 &&
+            !isBroken(jobName, job)) {
+            results.insert(jobName);
+            expansionFound = true;
+        }
+    }
+
+    return expansionFound;
+}
+} // namespace
+
+auto resolveNamedConstituents(const std::map<std::string, nlohmann::json> &jobs)
+    -> std::variant<std::vector<AggregateJob>, DependencyCycle> {
+    std::set<AggregateJob> aggregateJobs;
+    for (auto const &[jobName, job] : jobs) {
+        auto named = job.find("namedConstituents");
+        if (named != job.end() && !named->empty()) {
+            bool globConstituents = job.value<bool>("globConstituents", false);
+            std::unordered_map<std::string, std::string> brokenJobs;
+            std::set<std::string> results;
+
+            auto isBroken = [&brokenJobs,
+                             &jobName](const std::string &childJobName,
+                                       const nlohmann::json &job) -> bool {
+                if (job.find("error") != job.end()) {
+                    std::string error = job["error"];
+                    nix::logger->log(
+                        nix::lvlError,
+                        nix::fmt(
+                            "aggregate job '%s' references broken job '%s': %s",
+                            jobName, childJobName, error));
+                    brokenJobs[childJobName] = error;
+                    return true;
+                }
+                return false;
+            };
+
+            for (const std::string childJobName : *named) {
+                auto childJobIter = jobs.find(childJobName);
+                if (childJobIter == jobs.end()) {
+                    if (!globConstituents) {
+                        nix::logger->log(
+                            nix::lvlError,
+                            nix::fmt("aggregate job '%s' references "
+                                     "non-existent job '%s'",
+                                     jobName, childJobName));
+                        brokenJobs[childJobName] = "does not exist";
+                    } else if (!insertMatchingConstituents(childJobName,
+                                                           jobName, isBroken,
+                                                           jobs, results)) {
+                        nix::warn("aggregate job '%s' references constituent "
+                                  "glob pattern '%s' with no matches",
+                                  jobName, childJobName);
+                        brokenJobs[childJobName] =
+                            "constituent glob pattern had no matches";
+                    }
+                } else if (!isBroken(childJobName, childJobIter->second)) {
+                    results.insert(childJobName);
+                }
+            }
+
+            aggregateJobs.insert(AggregateJob(jobName, results, brokenJobs));
+        }
+    }
+
+    try {
+        return topoSort(aggregateJobs);
+    } catch (DependencyCycle &e) {
+        return e;
+    }
+}
+
+void rewriteAggregates(std::map<std::string, nlohmann::json> &jobs,
+                       const std::vector<AggregateJob> &aggregateJobs,
+                       nix::ref<nix::Store> &store, nix::Path &gcRootsDir) {
+    for (const auto &aggregateJob : aggregateJobs) {
+        auto &job = jobs.find(aggregateJob.name)->second;
+        auto drvPath = store->parseStorePath(std::string(job["drvPath"]));
+        auto drv = store->readDerivation(drvPath);
+
+        if (aggregateJob.brokenJobs.empty()) {
+            for (const auto &childJobName : aggregateJob.dependencies) {
+                auto childDrvPath = store->parseStorePath(
+                    std::string(jobs.find(childJobName)->second["drvPath"]));
+                auto childDrv = store->readDerivation(childDrvPath);
+                job["constituents"].push_back(
+                    store->printStorePath(childDrvPath));
+                drv.inputDrvs.map[childDrvPath].value = {
+                    childDrv.outputs.begin()->first};
+            }
+
+            std::string drvName(drvPath.name());
+            assert(nix::hasSuffix(drvName, nix::drvExtension));
+            drvName.resize(drvName.size() - nix::drvExtension.size());
+
+            auto hashModulo = hashDerivationModulo(*store, drv, true);
+            if (hashModulo.kind != nix::DrvHash::Kind::Regular) {
+                continue;
+            }
+            auto h = hashModulo.hashes.find("out");
+            if (h == hashModulo.hashes.end()) {
+                continue;
+            }
+            auto outPath = store->makeOutputPath("out", h->second, drvName);
+            drv.env["out"] = store->printStorePath(outPath);
+            drv.outputs.insert_or_assign(
+                "out", nix::DerivationOutput::InputAddressed{.path = outPath});
+
+            auto newDrvPath = nix::writeDerivation(*store, drv);
+            auto newDrvPathS = store->printStorePath(newDrvPath);
+
+            /* Register the derivation as a GC root.  !!! This
+                registers roots for jobs that we may have already
+                done. */
+            auto localStore = store.dynamic_pointer_cast<nix::LocalFSStore>();
+            assert(!gcRootsDir.empty());
+            const nix::Path root =
+                gcRootsDir + "/" + std::string(nix::baseNameOf(newDrvPathS));
+            if (!nix::pathExists(root)) {
+                localStore->addPermRoot(newDrvPath, root);
+            }
+
+            nix::logger->log(nix::lvlDebug,
+                             nix::fmt("rewrote aggregate derivation %s -> %s",
+                                      store->printStorePath(drvPath),
+                                      newDrvPathS));
+
+            job["drvPath"] = newDrvPathS;
+            job["outputs"]["out"] = store->printStorePath(outPath);
+        }
+
+        job.erase("namedConstituents");
+
+        if (!aggregateJob.brokenJobs.empty()) {
+            std::stringstream ss;
+            for (const auto &[jobName, error] : aggregateJob.brokenJobs) {
+                ss << jobName << ": " << error << "\n";
+            }
+            job["error"] = ss.str();
+        }
+
+        std::cout << job.dump() << "\n" << std::flush;
+    }
+}

--- a/src/constituents.hh
+++ b/src/constituents.hh
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "fmt.hh"
+#include <map>
+#include <nlohmann/json_fwd.hpp>
+#include <set>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include <nix/config.h>
+#include <nix/store-api.hh>
+
+struct DependencyCycle : public std::exception {
+    std::string a;
+    std::string b;
+    std::set<std::string> remainingAggregates;
+
+    DependencyCycle(std::string a, std::string b,
+                    const std::set<std::string> &remainingAggregates)
+        : a(std::move(a)), b(std::move(b)),
+          remainingAggregates(remainingAggregates) {}
+
+    [[nodiscard]] auto message() const -> std::string {
+        return nix::fmt("Dependency cycle: %s <-> %s", a, b);
+    }
+};
+
+struct AggregateJob {
+    std::string name;
+    std::set<std::string> dependencies;
+    std::unordered_map<std::string, std::string> brokenJobs;
+
+    auto operator<(const AggregateJob &b) const -> bool {
+        return name < b.name;
+    }
+};
+
+auto resolveNamedConstituents(const std::map<std::string, nlohmann::json> &jobs)
+    -> std::variant<std::vector<AggregateJob>, DependencyCycle>;
+
+void rewriteAggregates(std::map<std::string, nlohmann::json> &jobs,
+                       const std::vector<AggregateJob> &aggregateJobs,
+                       nix::ref<nix::Store> &store, nix::Path &gcRootsDir);

--- a/src/drv.cc
+++ b/src/drv.cc
@@ -235,6 +235,7 @@ void to_json(nlohmann::json &json, const Drv &drv) {
     if (auto constituents = drv.constituents) {
         json["constituents"] = constituents->constituents;
         json["namedConstituents"] = constituents->namedConstituents;
+        json["globConstituents"] = constituents->globConstituents;
     }
 
     if (drv.cacheStatus != Drv::CacheStatus::Unknown) {

--- a/src/drv.hh
+++ b/src/drv.hh
@@ -21,10 +21,13 @@ struct PackageInfo;
 struct Constituents {
     std::vector<std::string> constituents;
     std::vector<std::string> namedConstituents;
+    bool globConstituents;
     Constituents(std::vector<std::string> constituents,
-                 std::vector<std::string> namedConstituents)
+                 std::vector<std::string> namedConstituents,
+                 bool globConstituents)
         : constituents(std::move(constituents)),
-          namedConstituents(std::move(namedConstituents)) {};
+          namedConstituents(std::move(namedConstituents)),
+          globConstituents(globConstituents) {};
 };
 
 /* The fields of a derivation that are printed in json form */

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,7 @@ src = [
   'eval-args.cc',
   'drv.cc',
   'buffered-io.cc',
+  'constituents.cc',
   'worker.cc',
   'strings-portable.cc'
 ]

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -58,6 +58,7 @@
 #include "buffered-io.hh"
 #include "worker.hh"
 #include "strings-portable.hh"
+#include "constituents.hh"
 
 namespace {
 MyArgs myArgs; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -465,99 +466,33 @@ auto main(int argc, char **argv) -> int {
             auto store = myArgs.evalStoreUrl
                              ? nix::openStore(*myArgs.evalStoreUrl)
                              : nix::openStore();
-            for (auto &[attr, job_json] : state->jobs) {
-                auto namedConstituents = job_json.find("namedConstituents");
-                if (namedConstituents != job_json.end() &&
-                    !namedConstituents->empty()) {
-                    bool broken = false;
-                    auto drvPathAggregate = store->parseStorePath(
-                        static_cast<std::string>(job_json["drvPath"]));
-                    auto drvAggregate = store->readDerivation(drvPathAggregate);
-                    if (!job_json.contains("constituents")) {
-                        job_json["constituents"] = nlohmann::json::array();
-                    }
-                    std::vector<std::string> errors;
-                    for (const auto &child : *namedConstituents) {
-                        auto childJob = state->jobs.find(child);
-                        if (childJob == state->jobs.end()) {
-                            broken = true;
-                            errors.push_back(
-                                nix::fmt("%s: does not exist", child));
-                        } else if (childJob->second.find("error") !=
-                                   childJob->second.end()) {
-                            broken = true;
-                            errors.push_back(nix::fmt(
-                                "%s: %s", child, childJob->second["error"]));
-                        } else {
-                            auto drvPathChild =
-                                store->parseStorePath(static_cast<std::string>(
-                                    childJob->second["drvPath"]));
-                            auto drvChild = store->readDerivation(drvPathChild);
-                            job_json["constituents"].push_back(
-                                store->printStorePath(drvPathChild));
-                            drvAggregate.inputDrvs.map[drvPathChild].value = {
-                                drvChild.outputs.begin()->first};
+
+            std::visit(
+                nix::overloaded{
+                    [&](const std::vector<AggregateJob> &namedConstituents) {
+                        rewriteAggregates(state->jobs, namedConstituents, store,
+                                          myArgs.gcRootsDir);
+                    },
+                    [&](const DependencyCycle &e) {
+                        nix::logger->log(nix::lvlError,
+                                         nix::fmt("Found dependency cycle "
+                                                  "between jobs '%s' and '%s'",
+                                                  e.a, e.b));
+                        state->jobs[e.a]["error"] = e.message();
+                        state->jobs[e.b]["error"] = e.message();
+
+                        std::cout << state->jobs[e.a].dump() << "\n"
+                                  << state->jobs[e.b].dump() << "\n";
+
+                        for (const auto &jobName : e.remainingAggregates) {
+                            state->jobs[jobName]["error"] =
+                                "Skipping aggregate because of a dependency "
+                                "cycle";
+                            std::cout << state->jobs[jobName].dump() << "\n";
                         }
-                    }
-
-                    if (broken) {
-                        nlohmann::json out;
-                        out["attr"] = job_json["attr"];
-                        out["error"] = nix::concatStringsSep("\n", errors);
-                        out["constituents"] = nlohmann::json::array();
-                        std::cout << out.dump() << "\n" << std::flush;
-                    } else {
-                        std::string drvName(drvPathAggregate.name());
-                        assert(drvName.ends_with(nix::drvExtension));
-                        drvName.resize(drvName.size() -
-                                       nix::drvExtension.size());
-
-                        auto hashModulo = nix::hashDerivationModulo(
-                            *store, drvAggregate, true);
-                        if (hashModulo.kind != nix::DrvHash::Kind::Regular) {
-                            continue;
-                        }
-
-                        auto h = hashModulo.hashes.find("out");
-                        if (h == hashModulo.hashes.end()) {
-                            continue;
-                        }
-                        auto outPath =
-                            store->makeOutputPath("out", h->second, drvName);
-                        drvAggregate.env["out"] =
-                            store->printStorePath(outPath);
-                        drvAggregate.outputs.insert_or_assign(
-                            "out", nix::DerivationOutput::InputAddressed{
-                                       .path = outPath});
-                        auto newDrvPath =
-                            nix::writeDerivation(*store, drvAggregate);
-                        auto newDrvPathS = store->printStorePath(newDrvPath);
-
-                        assert(!myArgs.gcRootsDir.empty());
-                        const nix::Path root =
-                            myArgs.gcRootsDir + "/" +
-                            std::string(nix::baseNameOf(newDrvPathS));
-
-                        if (!nix::pathExists(root)) {
-                            auto localStore =
-                                store.dynamic_pointer_cast<nix::LocalFSStore>();
-                            localStore->addPermRoot(newDrvPath, root);
-                        }
-
-                        nix::logger->log(
-                            nix::lvlDebug,
-                            nix::fmt("rewrote aggregate derivation %s -> %s",
-                                     store->printStorePath(drvPathAggregate),
-                                     newDrvPathS));
-
-                        job_json["drvPath"] = newDrvPathS;
-                        job_json["outputs"]["out"] =
-                            store->printStorePath(outPath);
-                        job_json.erase("namedConstituents");
-                        std::cout << job_json.dump() << "\n" << std::flush;
-                    }
-                }
-            }
+                    },
+                },
+                resolveNamedConstituents(state->jobs));
         }
     });
 }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -151,6 +151,7 @@ void worker(
                     if (args.constituents) {
                         std::vector<std::string> constituents;
                         std::vector<std::string> namedConstituents;
+                        bool globConstituents = false;
                         const auto *a = v->attrs()->get(
                             state->symbols.create("_hydraAggregate"));
                         if (a != nullptr &&
@@ -200,9 +201,19 @@ void worker(
                                     namedConstituents.emplace_back(v->c_str());
                                 }
                             }
+
+                            const auto *glob =
+                                v->attrs()->get(state->symbols.create(
+                                    "_hydraGlobConstituents"));
+                            globConstituents =
+                                glob != nullptr &&
+                                state->forceBool(
+                                    *glob->value, glob->pos,
+                                    "while evaluating the "
+                                    "`_hydraGlobConstituents` attribute");
                         }
-                        maybeConstituents =
-                            Constituents(constituents, namedConstituents);
+                        maybeConstituents = Constituents(
+                            constituents, namedConstituents, globConstituents);
                     }
                     auto drv = Drv(attrPathS, *state, *packageInfo, args,
                                    maybeConstituents);

--- a/tests/assets/flake.nix
+++ b/tests/assets/flake.nix
@@ -77,6 +77,60 @@
               '';
           doesnteval = pkgs.writeText "constituent" (toString { });
         };
+        glob1 = {
+          constituentA = pkgs.runCommand "constituentA" { } "touch $out";
+          constituentB = pkgs.runCommand "constituentB" { } "touch $out";
+          aggregate = pkgs.runCommand "aggregate" {
+            _hydraAggregate = true;
+            _hydraGlobConstituents = true;
+            constituents = [ "*" ];
+          } "touch $out";
+        };
+        cycle = {
+          aggregate0 = pkgs.runCommand "aggregate0" {
+            _hydraAggregate = true;
+            _hydraGlobConstituents = true;
+            constituents = [ "aggregate1" ];
+          } "touch $out";
+          aggregate1 = pkgs.runCommand "aggregate1" {
+            _hydraAggregate = true;
+            _hydraGlobConstituents = true;
+            constituents = [ "aggregate0" ];
+          } "touch $out";
+        };
+        glob2 = rec {
+          packages = pkgs.recurseIntoAttrs {
+            constituentA = pkgs.runCommand "constituentA" { } "touch $out";
+            constituentB = pkgs.runCommand "constituentB" { } "touch $out";
+          };
+          aggregate0 = pkgs.runCommand "aggregate0" {
+            _hydraAggregate = true;
+            _hydraGlobConstituents = true;
+            constituents = [
+              "packages.*"
+            ];
+          } "touch $out";
+          aggregate1 = pkgs.runCommand "aggregate1" {
+            _hydraAggregate = true;
+            _hydraGlobConstituents = true;
+            constituents = [
+              "tests.*"
+            ];
+          } "touch $out";
+          indirect_aggregate0 = pkgs.runCommand "indirect_aggregate0" {
+            _hydraAggregate = true;
+            constituents = [
+              "aggregate0"
+            ];
+          } "touch $out";
+          mix_aggregate0 = pkgs.runCommand "mix_aggregate0" {
+            _hydraAggregate = true;
+            constituents = [
+              "aggregate0"
+              packages.constituentA
+            ];
+          } "touch $out";
+        };
       };
     };
 }

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -178,6 +178,112 @@ def test_constituents() -> None:
         check_gc_root(tempdir, mixed["drvPath"])
 
 
+def test_constituents_all() -> None:
+    with TemporaryDirectory() as tempdir:
+        cmd = [
+            str(BIN),
+            "--gc-roots-dir",
+            tempdir,
+            "--meta",
+            "--workers",
+            "1",
+            "--flake",
+            ".#legacyPackages.x86_64-linux.glob1",
+            "--constituents",
+        ]
+        res = subprocess.run(
+            cmd,
+            cwd=TEST_ROOT.joinpath("assets"),
+            text=True,
+            stdout=subprocess.PIPE,
+        )
+        print(res.stdout)
+        results = [json.loads(r) for r in res.stdout.split("\n") if r]
+        assert len(results) == 3
+        assert list(map(lambda x: x["name"], results)) == [
+            "constituentA",
+            "constituentB",
+            "aggregate",
+        ]
+        aggregate = results[2]
+        assert len(aggregate["constituents"]) == 2
+        assert aggregate["constituents"][0].endswith("constituentA.drv")
+        assert aggregate["constituents"][1].endswith("constituentB.drv")
+
+
+def test_constituents_glob_misc() -> None:
+    with TemporaryDirectory() as tempdir:
+        cmd = [
+            str(BIN),
+            "--gc-roots-dir",
+            tempdir,
+            "--meta",
+            "--workers",
+            "1",
+            "--flake",
+            ".#legacyPackages.x86_64-linux.glob2",
+            "--constituents",
+        ]
+        res = subprocess.run(
+            cmd,
+            cwd=TEST_ROOT.joinpath("assets"),
+            text=True,
+            stdout=subprocess.PIPE,
+        )
+        print(res.stdout)
+        results = [json.loads(r) for r in res.stdout.split("\n") if r]
+        assert len(results) == 6
+        assert list(map(lambda x: x["name"], results)) == [
+            "constituentA",
+            "constituentB",
+            "aggregate0",
+            "aggregate1",
+            "indirect_aggregate0",
+            "mix_aggregate0",
+        ]
+        aggregate = results[2]
+        assert len(aggregate["constituents"]) == 2
+        assert aggregate["constituents"][0].endswith("constituentA.drv")
+        assert aggregate["constituents"][1].endswith("constituentB.drv")
+        aggregate = results[4]
+        assert len(aggregate["constituents"]) == 1
+        assert aggregate["constituents"][0].endswith("aggregate0.drv")
+        failed = results[3]
+        assert "constituents" in failed
+        assert failed["error"] == "tests.*: constituent glob pattern had no matches\n"
+
+        assert results[4]["constituents"][0] == results[2]["drvPath"]
+        assert results[5]["constituents"][0] == results[0]["drvPath"]
+        assert results[5]["constituents"][1] == results[2]["drvPath"]
+
+
+def test_constituents_cycle() -> None:
+    with TemporaryDirectory() as tempdir:
+        cmd = [
+            str(BIN),
+            "--gc-roots-dir",
+            tempdir,
+            "--meta",
+            "--workers",
+            "1",
+            "--flake",
+            ".#legacyPackages.x86_64-linux.cycle",
+            "--constituents",
+        ]
+        res = subprocess.run(
+            cmd,
+            cwd=TEST_ROOT.joinpath("assets"),
+            text=True,
+            stdout=subprocess.PIPE,
+        )
+        print(res.stdout)
+        results = [json.loads(r) for r in res.stdout.split("\n") if r]
+        assert len(results) == 2
+        assert list(map(lambda x: x["name"], results)) == ["aggregate0", "aggregate1"]
+        for i in results:
+            assert i["error"] == "Dependency cycle: aggregate0 <-> aggregate1"
+
+
 def test_constituents_error() -> None:
     with TemporaryDirectory() as tempdir:
         cmd = [
@@ -206,10 +312,9 @@ def test_constituents_error() -> None:
         aggregate = results[1]
         assert aggregate["attr"] == "aggregate"
         assert "namedConstituents" not in aggregate
-        assert aggregate["error"].startswith(
-            '"doesntexist": does not exist\n"doesnteval": "error:'
-        )
-        assert aggregate["constituents"] == []
+        assert "\ndoesntexist: does not exist\n" in aggregate["error"]
+        assert aggregate["error"].startswith("doesnteval: error:")
+        assert "constituents" in aggregate
 
 
 @pytest.mark.infiniterecursion

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -312,8 +312,7 @@ def test_constituents_error() -> None:
         aggregate = results[1]
         assert aggregate["attr"] == "aggregate"
         assert "namedConstituents" not in aggregate
-        assert "\ndoesntexist: does not exist\n" in aggregate["error"]
-        assert aggregate["error"].startswith("doesnteval: error:")
+        assert "doesntexist: does not exist\n" in aggregate["error"]
         assert "constituents" in aggregate
 
 


### PR DESCRIPTION
Given that CppNix' n-e-j already uses my patches to bring back constituents[1], I decided to also submit the part that allows globbing in hydra-eval-jobs to this repo[2].

This basically allows you to do

    constituents = [ "nixos.*" ];

to select all jobs starting with nixos. as constituents. Additionally, it fixes a bug in Hydra (that's also present here probably) where transitive constituent jobs may be discarded silently if declared by string instead of by derivation.

Given that the code became slightly larger and this part of the evaluation shouldn't blow up `main` even more, I decided to move it to its own compilation unit. Also fixed all the suggestions from the linter in the diff.

[1] https://determinate.systems/posts/hydra-deployment-source-of-truth/#aggregate-jobs
[2] https://github.com/NixOS/hydra/pull/1425

cc @ctheune @mic92 @Ericson2314 