### PR TITLE
no longer override restrict-eval

### DIFF
--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -451,10 +451,6 @@ auto main(int argc, char **argv) -> int {
          * causing "unexpected EOF" during eval */
         nix::settings.builders = "";
 
-        /* Prevent access to paths outside of the Nix search path and
-           to the environment. */
-        nix::evalSettings.restrictEval = false;
-
         /* When building a flake, use pure evaluation (no access to
            'getEnv', 'currentSystem' etc. */
         if (myArgs.impure) {


### PR DESCRIPTION
this has no effect and it should be up to the user to decide if they want restrict-eval or not.