### PR TITLE
add select flag to filter expressions before evaluation

### DIFF
--- a/src/eval-args.cc
+++ b/src/eval-args.cc
@@ -209,6 +209,28 @@ MyArgs::MyArgs() : MixCommonArgs("nix-eval-jobs") {
         .experimentalFeature = std::nullopt,
     });
 
+    addFlag({
+        .longName = "select",
+        .aliases = {},
+        .shortName = 0,
+        .description =
+            "Apply provided Nix function to transform the evaluation root. "
+            "This is applied before any attribute traversal begins. "
+            "When used with --flake without a fragment, the function receives "
+            "an attrset with 'outputs' and 'inputs'. "
+            "When used with a flake fragment, it receives the selected "
+            "attribute. "
+            "Examples: "
+            "--select 'flake: flake.outputs.packages' "
+            "--select 'flake: flake.inputs.nixpkgs' "
+            "--select 'outputs: outputs.packages.x86_64-linux'",
+        .category = "",
+        .labels = {"expr"},
+        .handler = {&selectExpr},
+        .completer = nullptr,
+        .experimentalFeature = std::nullopt,
+    });
+
     // usually in MixFlakeOptions
     addFlag({
         .longName = "override-input",

--- a/src/eval-args.hh
+++ b/src/eval-args.hh
@@ -15,6 +15,7 @@ class MyArgs : virtual public nix::MixEvalArgs,
     virtual ~MyArgs() = default;
     std::string releaseExpr;
     std::string applyExpr;
+    std::string selectExpr;
     nix::Path gcRootsDir;
     bool flake = false;
     bool fromArgs = false;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a --select CLI flag to filter/transform the evaluation root prior to attribute traversal, with flake-aware behavior for fragments and whole-flake outputs.
