### PR TITLE
 bump to nix 2.31

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,24 +1,17 @@
 Checks: >
   - bugprone-*
-  - performance-*
-  - modernize-*
-  - readability-*
-  - misc-*
-  - portability-*
   - concurrency-*
+  - cppcoreguidelines-*
   - google-*
+  - misc-*
+  - modernize-*
+  - performance-*
+  - portability-*
+  - readability-*
   - -google-readability-todo
 
   # don't find them too problematic
-  - -readability-identifier-length
-  - -readability-magic-numbers
   - -bugprone-easily-swappable-parameters
-
-  # maybe address this in the future
-  - -readability-function-cognitive-complexity
-
-  - cppcoreguidelines-*
-  - -cppcoreguidelines-avoid-magic-numbers
 UseColor: true
 CheckOptions:
   misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: True

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,16 +1,7 @@
 Checks: >
-  - bugprone-*
-  - concurrency-*
-  - cppcoreguidelines-*
-  - google-*
-  - misc-*
-  - modernize-*
-  - performance-*
-  - portability-*
-  - readability-*
+  - '*' # Enable all checks
+  # Disabled checks
   - -google-readability-todo
-
-  # don't find them too problematic
   - -bugprone-easily-swappable-parameters
 UseColor: true
 CheckOptions:

--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ USAGE: nix-eval-jobs [options] expr
   --log-format           Set the format of log output; one of `raw`, `internal-json`, `bar` or `bar-with-logs`.
   --max-memory-size      maximum evaluation memory size in megabyte (4GiB per worker by default)
   --meta                 include derivation meta field in output
+  --no-instantiate       don't instantiate (write) derivations, only evaluate (faster)
   --option               Set the Nix configuration setting *name* to *value* (overriding `nix.conf`).
   --override-flake       Override the flake registries, redirecting *original-ref* to *resolved-ref*.
   --override-input       Override a specific flake input (e.g. `dwarffs/nixpkgs`).
   --quiet                Decrease the logging verbosity level.
   --reference-lock-file  Read the given lock file instead of `flake.lock` within the top-level flake.
   --repair               During evaluation, rewrite missing or corrupted files in the Nix store. During building, rebuild missing or corrupted store paths.
+  --select               Apply provided Nix function to transform the evaluation root. This is applied before any attribute traversal begins. When used with --flake without a fragment, the function receives an attrset with 'outputs' and 'inputs'. When used with a flake fragment, it receives the selected attribute. Examples: --select 'flake: flake.outputs.packages' --select 'flake: flake.inputs.nixpkgs' --select 'outputs: outputs.packages.x86_64-linux'
   --show-input-drvs      Show input derivations in the output for each derivation. This is useful to get direct dependencies of a derivation.
   --show-trace           print out a stack trace in case of evaluation errors
   --verbose              Increase the logging verbosity level.

--- a/flake.lock
+++ b/flake.lock
@@ -23,16 +23,16 @@
     "nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1752054614,
-        "narHash": "sha256-GMLWJVc1nyRf5FA+qn2D/jEjCf8lXJpkFRTYyKiKte4=",
+        "lastModified": 1756804961,
+        "narHash": "sha256-TUkkfeQnfI7569O7bWI/v01GJct0OPYydLwINC6ksRo=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "ed8f7df56d49d19a80ff0566cd8c80db752669ac",
+        "rev": "e7540a269b3b711d67ae27b1bc2f93cc2d39eb21",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "2.30-maintenance",
+        "ref": "2.31-maintenance",
         "repo": "nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   # inputs.nixpkgs.url = "https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz";
   inputs.nixpkgs.url = "github:nixos/nixpkgs";
   inputs.nix = {
-    url = "github:NixOS/nix/2.30-maintenance";
+    url = "github:NixOS/nix/2.31-maintenance";
     # We want to control the deps precisely
     flake = false;
   };

--- a/src/drv.cc
+++ b/src/drv.cc
@@ -1,6 +1,7 @@
 #include <nix/store/path-with-outputs.hh>
 #include <nix/store/store-api.hh>
 #include <nix/store/local-fs-store.hh>
+#include <nix/store/globals.hh>
 #include <nix/expr/value-to-json.hh>
 #include <nix/store/derivations.hh>
 #include <nix/expr/get-drvs.hh>

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -6,6 +6,7 @@
 #include <nix/util/terminal.hh>
 #include <nix/expr/attr-path.hh>
 #include <nix/store/local-fs-store.hh>
+#include <nix/store/globals.hh>
 #include <nix/cmd/installable-flake.hh>
 #include <nix/expr/value-to-json.hh>
 #include <sys/resource.h>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Documented two new CLI options: --no-instantiate and --select, with usage details and examples.

* Chores
  * Updated Nix dependency to 2.31-maintenance.
  * Minor internal include adjustments with no user-visible behavior changes.

* Style
  * Re-enabled many readability and guideline checks in static analysis while suppressing a small set of specific checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->