### PR TITLE
make nix-eval-jobs automatically use nix's major minor version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,9 +5,12 @@
   pkgs,
 }:
 
+let
+  revision = "0";
+in
 stdenv.mkDerivation {
   pname = "nix-eval-jobs";
-  version = "2.30.0";
+  version = "${lib.versions.majorMinor nixComponents.nix-cli.version}.${revision}";
   src = lib.fileset.toSource {
     fileset = lib.fileset.unions [
       ./.clang-tidy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Switched to a dynamic versioning scheme tied to the nix-cli major/minor version with a revision suffix, replacing the fixed version.
  * Version strings shown in the CLI and package metadata will reflect upstream compatibility and incremental revisions.
  * Improves consistency across releases and simplifies maintenance.
  * No functional changes to behavior; if you parse version strings in scripts or tooling, review and update them to handle the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->