### PR TITLE
Add --show-required-system-features flag to display derivation system requirements

### DIFF
--- a/src/drv.hh
+++ b/src/drv.hh
@@ -1,5 +1,6 @@
 #include <nix/expr/get-drvs.hh>
 #include <nix/expr/eval.hh>
+#include <nix/util/types.hh>
 #include <nlohmann/json_fwd.hpp>
 // we need this include or otherwise we cannot instantiate std::optional
 #include <nlohmann/json.hpp> //NOLINT(misc-include-cleaner)
@@ -43,6 +44,8 @@ struct Drv {
 
     std::optional<std::map<std::string, std::set<std::string>>> inputDrvs =
         std::nullopt;
+
+    std::optional<nix::StringSet> requiredSystemFeatures = std::nullopt;
 
     // TODO: can we lazily allocate these?
     std::vector<std::string> neededBuilds;

--- a/tests/assets/ci.nix
+++ b/tests/assets/ci.nix
@@ -32,6 +32,7 @@ in
       "-c"
       "echo 'job1' > $out"
     ];
+    requiredSystemFeatures = [ "big-parallel" ];
   };
 
   dontRecurse = {

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -70,6 +70,7 @@ def test_flake() -> None:
         assert "cacheStatus" not in result
         assert "neededBuilds" not in result
         assert "neededSubstitutes" not in result
+        assert "requiredSystemFeatures" in result
 
 
 def test_query_cache_status() -> None:
@@ -88,6 +89,10 @@ def test_expression() -> None:
     for result in results:
         assert "isCached" not in result  # legacy
         assert "cacheStatus" not in result
+        assert "requiredSystemFeatures" in result
+        if result["attr"] == "builtJob":
+            assert isinstance(result["requiredSystemFeatures"], list)
+            assert "big-parallel" in result["requiredSystemFeatures"]
 
     with open(TEST_ROOT.joinpath("assets/ci.nix")) as ci_nix:
         common_test(["-E", ci_nix.read()])
@@ -574,6 +579,9 @@ def test_no_instantiate_mode() -> None:
 
             # Input drvs should not be present (requires reading derivation from store)
             assert "inputDrvs" not in result
+
+            # Required system features should not be present (requires reading derivation from store)
+            assert "requiredSystemFeatures" not in result
 
         # Verify specific outputs for known derivations
         built_job = next(r for r in results if r["attr"] == "builtJob")


### PR DESCRIPTION
Adds optional support for querying and displaying requiredSystemFeatures from derivations. We can then use this information to ensure builds are scheduled on compatible systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Results now include requiredSystemFeatures when available, inferred from derivations and attributes and emitted in JSON, making system feature requirements visible for builds.
* **Tests**
  * Added assertions to validate presence and structure of requiredSystemFeatures in evaluation results.
  * Updated test assets with an example derivation specifying requiredSystemFeatures (e.g., "big-parallel") to verify handling and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->