### PR TITLE
drv: short-circuit cache-status check on output substitutability

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
                   nativeBuildInputs = [
                     self'.packages.nix-eval-jobs
                     pkgs.python3.pkgs.pytest
+                    pkgs.nix
                   ];
                 }
                 ''

--- a/src/drv.cc
+++ b/src/drv.cc
@@ -1,3 +1,4 @@
+#include <nix/store/path-info.hh>
 #include <nix/store/path-with-outputs.hh>
 #include <nix/store/store-api.hh>
 #include <nix/store/local-fs-store.hh>
@@ -105,6 +106,45 @@ auto queryInputDrvs(const nix::Derivation &drv)
     return drvs;
 }
 
+// queryMissing's per-input traversal flags an FOD as willBuild whenever a
+// build-time-only input is missing from substituters, even though `nix build`
+// would just download the FOD's own output. Returns Local/Cached when every
+// output is already obtainable; nullopt means the caller should fall through
+// to queryMissing so its per-input breakdown still populates neededBuilds for
+// cross-system jobs (issue #369).
+auto checkOutputsAvailable(
+    nix::Store &store,
+    std::map<std::string, std::optional<nix::StorePath>> &outputs,
+    std::vector<nix::StorePath> &neededSubstitutes)
+    -> std::optional<Drv::CacheStatus> {
+    nix::StorePathCAMap toQuery;
+    for (auto const &[outputName, outputPath] : outputs) {
+        if (!outputPath) {
+            return std::nullopt;
+        }
+        if (!store.isValidPath(*outputPath)) {
+            toQuery.insert({*outputPath, std::nullopt});
+        }
+    }
+    nix::SubstitutablePathInfos infos;
+    if (!toQuery.empty()) {
+        store.querySubstitutablePathInfos(toQuery, infos);
+    }
+    if (infos.size() != toQuery.size()) {
+        return std::nullopt;
+    }
+    for (auto const &[path, info] : infos) {
+        neededSubstitutes.push_back(path);
+    }
+    std::ranges::sort(
+        neededSubstitutes,
+        [](const nix::StorePath &lhs, const nix::StorePath &rhs) -> bool {
+            return lhs.name() != rhs.name() ? lhs.name() < rhs.name()
+                                            : lhs.to_string() < rhs.to_string();
+        });
+    return infos.empty() ? Drv::CacheStatus::Local : Drv::CacheStatus::Cached;
+}
+
 auto queryCacheStatus(
     nix::Store &store,
     std::map<std::string, std::optional<nix::StorePath>> &outputs,
@@ -113,15 +153,19 @@ auto queryCacheStatus(
     std::vector<nix::StorePath> &unknownPaths, const nix::Derivation &drv)
     -> Drv::CacheStatus {
 
+    if (auto cached =
+            checkOutputsAvailable(store, outputs, neededSubstitutes)) {
+        return *cached;
+    }
+
     std::vector<nix::StorePathWithOutputs> paths;
-    // Add output paths
     for (auto const &[key, val] : outputs) {
         if (val) {
             paths.push_back(nix::StorePathWithOutputs{*val, {}});
         }
     }
-
-    // Add input derivation paths
+    // Input drvs go in too so neededBuilds is populated for cross-system jobs
+    // whose own output paths are unknown (issue #369).
     for (const auto &[inputDrvPath, inputNode] : drv.inputDrvs.map) {
         paths.push_back(
             nix::StorePathWithOutputs(inputDrvPath, inputNode.value));

--- a/tests-functional/assets/flake.nix
+++ b/tests-functional/assets/flake.nix
@@ -15,253 +15,307 @@
             "echo '${text}' > $out"
           ];
         };
+
+      forEachSystem =
+        f:
+        builtins.listToAttrs (
+          map
+            (s: {
+              name = s;
+              value = f s;
+            })
+            [
+              "aarch64-darwin"
+              "aarch64-linux"
+              "x86_64-darwin"
+              "x86_64-linux"
+            ]
+        );
+
     in
     {
       hydraJobs = import ./ci.nix { inherit system; };
 
-      legacyPackages.x86_64-linux = {
-        emptyNeeded = rec {
-          # This is a reproducer for issue #369 where neededBuilds and neededSubstitutes are empty
-          # when they should contain values
-          nginx = derivation {
-            name = "nginx-1.24.0";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo 'content' > $out"
-            ];
-          };
-          proxyWrapper = derivation {
-            name = "proxyWrapper";
-            system = "aarch64-linux";
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo '${nginx}' > $out"
-            ];
-          };
-          webService = derivation {
-            name = "webService";
-            system = "aarch64-linux";
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo '${proxyWrapper}' > $out"
-            ];
-          };
-        };
-        brokenPkgs = {
-          brokenPackage = throw "this is an evaluation error";
-        };
-        infiniteRecursionPkgs = {
-          packageWithInfiniteRecursion =
-            let
-              recursion = [ recursion ];
-            in
-            derivation {
-              inherit system;
-              name = "drvB";
-              recursiveAttr = recursion;
-              builder = ":";
+      # See test_fod_with_uncached_input_issue413. fodIssue413 is provided on
+      # every system the test runs on; its FOD output is the sha256 of "hi\n".
+      legacyPackages = forEachSystem (
+        s:
+        {
+          fodIssue413 = rec {
+            neverCached = derivation {
+              name = "never-cached";
+              system = s;
+              builder = "/bin/sh";
+              # No coreutils on PATH when sandbox=false in the test env.
+              args = [
+                "-c"
+                "echo never-cached > $out"
+              ];
             };
-        };
-        success = {
-          indirect_aggregate = derivation {
-            name = "indirect_aggregate";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-            _hydraAggregate = true;
-            constituents = [
-              "anotherone"
-            ];
-          };
-          direct_aggregate = derivation {
-            name = "direct_aggregate";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-            _hydraAggregate = true;
-            constituents = [
-              self.hydraJobs.builtJob
-            ];
-          };
-          mixed_aggregate = derivation {
-            name = "mixed_aggregate";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-            _hydraAggregate = true;
-            constituents = [
-              self.hydraJobs.builtJob
-              "anotherone"
-            ];
-          };
-          anotherone = makeTextDrv "constituent" "text";
-        };
-        failures = {
-          aggregate = derivation {
-            name = "aggregate";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-            _hydraAggregate = true;
-            constituents = [
-              "doesntexist"
-              "doesnteval"
-            ];
-          };
-          doesnteval = makeTextDrv "constituent" (toString { });
-        };
-        glob1 = {
-          constituentA = derivation {
-            name = "constituentA";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-          };
-          constituentB = derivation {
-            name = "constituentB";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-          };
-          aggregate = derivation {
-            name = "aggregate";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-            _hydraAggregate = true;
-            _hydraGlobConstituents = true;
-            constituents = [ "*" ];
-          };
-        };
-        cycle = {
-          aggregate0 = derivation {
-            name = "aggregate0";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-            _hydraAggregate = true;
-            _hydraGlobConstituents = true;
-            constituents = [ "aggregate1" ];
-          };
-          aggregate1 = derivation {
-            name = "aggregate1";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-            _hydraAggregate = true;
-            _hydraGlobConstituents = true;
-            constituents = [ "aggregate0" ];
-          };
-        };
-        glob2 = rec {
-          packages = {
-            recurseForDerivations = true;
-            constituentA = derivation {
-              name = "constituentA";
-              inherit system;
+            fod = derivation {
+              name = "fod";
+              system = s;
               builder = "/bin/sh";
               args = [
                 "-c"
-                "echo done > $out"
+                "echo hi > $out; : ${neverCached}"
               ];
-            };
-            constituentB = derivation {
-              name = "constituentB";
-              inherit system;
-              builder = "/bin/sh";
-              args = [
-                "-c"
-                "echo done > $out"
-              ];
+              outputHashMode = "flat";
+              outputHashAlgo = "sha256";
+              outputHash = "98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4";
             };
           };
-          aggregate0 = derivation {
-            name = "aggregate0";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-            _hydraAggregate = true;
-            _hydraGlobConstituents = true;
-            constituents = [
-              "packages.*"
-            ];
-          };
-          aggregate1 = derivation {
-            name = "aggregate1";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-            _hydraAggregate = true;
-            _hydraGlobConstituents = true;
-            constituents = [
-              "tests.*"
-            ];
-          };
-          indirect_aggregate0 = derivation {
-            name = "indirect_aggregate0";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-            _hydraAggregate = true;
-            constituents = [
-              "aggregate0"
-            ];
-          };
-          mix_aggregate0 = derivation {
-            name = "mix_aggregate0";
-            inherit system;
-            builder = "/bin/sh";
-            args = [
-              "-c"
-              "echo done > $out"
-            ];
-            _hydraAggregate = true;
-            constituents = [
-              "aggregate0"
-              packages.constituentA
-            ];
-          };
-        };
-      };
+        }
+        // (
+          if s != "x86_64-linux" then
+            { }
+          else
+            {
+
+              emptyNeeded = rec {
+                # This is a reproducer for issue #369 where neededBuilds and neededSubstitutes are empty
+                # when they should contain values
+                nginx = derivation {
+                  name = "nginx-1.24.0";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo 'content' > $out"
+                  ];
+                };
+                proxyWrapper = derivation {
+                  name = "proxyWrapper";
+                  system = "aarch64-linux";
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo '${nginx}' > $out"
+                  ];
+                };
+                webService = derivation {
+                  name = "webService";
+                  system = "aarch64-linux";
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo '${proxyWrapper}' > $out"
+                  ];
+                };
+              };
+              brokenPkgs = {
+                brokenPackage = throw "this is an evaluation error";
+              };
+              infiniteRecursionPkgs = {
+                packageWithInfiniteRecursion =
+                  let
+                    recursion = [ recursion ];
+                  in
+                  derivation {
+                    inherit system;
+                    name = "drvB";
+                    recursiveAttr = recursion;
+                    builder = ":";
+                  };
+              };
+              success = {
+                indirect_aggregate = derivation {
+                  name = "indirect_aggregate";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                  _hydraAggregate = true;
+                  constituents = [
+                    "anotherone"
+                  ];
+                };
+                direct_aggregate = derivation {
+                  name = "direct_aggregate";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                  _hydraAggregate = true;
+                  constituents = [
+                    self.hydraJobs.builtJob
+                  ];
+                };
+                mixed_aggregate = derivation {
+                  name = "mixed_aggregate";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                  _hydraAggregate = true;
+                  constituents = [
+                    self.hydraJobs.builtJob
+                    "anotherone"
+                  ];
+                };
+                anotherone = makeTextDrv "constituent" "text";
+              };
+              failures = {
+                aggregate = derivation {
+                  name = "aggregate";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                  _hydraAggregate = true;
+                  constituents = [
+                    "doesntexist"
+                    "doesnteval"
+                  ];
+                };
+                doesnteval = makeTextDrv "constituent" (toString { });
+              };
+              glob1 = {
+                constituentA = derivation {
+                  name = "constituentA";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                };
+                constituentB = derivation {
+                  name = "constituentB";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                };
+                aggregate = derivation {
+                  name = "aggregate";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                  _hydraAggregate = true;
+                  _hydraGlobConstituents = true;
+                  constituents = [ "*" ];
+                };
+              };
+              cycle = {
+                aggregate0 = derivation {
+                  name = "aggregate0";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                  _hydraAggregate = true;
+                  _hydraGlobConstituents = true;
+                  constituents = [ "aggregate1" ];
+                };
+                aggregate1 = derivation {
+                  name = "aggregate1";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                  _hydraAggregate = true;
+                  _hydraGlobConstituents = true;
+                  constituents = [ "aggregate0" ];
+                };
+              };
+              glob2 = rec {
+                packages = {
+                  recurseForDerivations = true;
+                  constituentA = derivation {
+                    name = "constituentA";
+                    inherit system;
+                    builder = "/bin/sh";
+                    args = [
+                      "-c"
+                      "echo done > $out"
+                    ];
+                  };
+                  constituentB = derivation {
+                    name = "constituentB";
+                    inherit system;
+                    builder = "/bin/sh";
+                    args = [
+                      "-c"
+                      "echo done > $out"
+                    ];
+                  };
+                };
+                aggregate0 = derivation {
+                  name = "aggregate0";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                  _hydraAggregate = true;
+                  _hydraGlobConstituents = true;
+                  constituents = [
+                    "packages.*"
+                  ];
+                };
+                aggregate1 = derivation {
+                  name = "aggregate1";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                  _hydraAggregate = true;
+                  _hydraGlobConstituents = true;
+                  constituents = [
+                    "tests.*"
+                  ];
+                };
+                indirect_aggregate0 = derivation {
+                  name = "indirect_aggregate0";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                  _hydraAggregate = true;
+                  constituents = [
+                    "aggregate0"
+                  ];
+                };
+                mix_aggregate0 = derivation {
+                  name = "mix_aggregate0";
+                  inherit system;
+                  builder = "/bin/sh";
+                  args = [
+                    "-c"
+                    "echo done > $out"
+                  ];
+                  _hydraAggregate = true;
+                  constituents = [
+                    "aggregate0"
+                    packages.constituentA
+                  ];
+                };
+              };
+            }
+        )
+      );
     };
 }

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
 
+import contextlib
+import functools
+import http.server
 import json
 import os
+import shutil
 import subprocess
+import threading
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
+
+import pytest
 
 TEST_ROOT = Path(__file__).parent.resolve()
 PROJECT_ROOT = TEST_ROOT.parent
@@ -586,3 +593,130 @@ def test_no_instantiate_mode() -> None:
 
         # No GC roots should be created in no-instantiate mode
         assert len(list(Path(tempdir).iterdir())) == 0
+
+
+# sandbox=false: NIX_STORE_DIR under /build collides with sandbox-build-dir
+# when these tests run inside a Nix build.
+_HERMETIC_NIX_OPTS = [
+    "--extra-experimental-features",
+    "nix-command flakes",
+    "--option",
+    "substituters",
+    "",
+    "--option",
+    "sandbox",
+    "false",
+    "--option",
+    "require-sigs",
+    "false",
+]
+
+
+def _hermetic_nix_env(tmp_path: Path) -> dict[str, str]:
+    """Per-test nix env that confines all stores/state/logs to tmp_path.
+
+    Mirrors nix's own functional-test setup (tests/functional/common/vars.sh)
+    so nix-collect-garbage etc. can never touch the host store.
+    """
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path / "home"),
+        "NIX_STORE_DIR": str(tmp_path / "store"),
+        "NIX_LOCALSTATE_DIR": str(tmp_path / "var"),
+        "NIX_STATE_DIR": str(tmp_path / "var/nix"),
+        "NIX_LOG_DIR": str(tmp_path / "var/log/nix"),
+        "NIX_CONF_DIR": str(tmp_path / "conf"),
+        "NIX_DAEMON_SOCKET_PATH": str(tmp_path / "daemon-socket"),
+        # Force single-user mode so the *_DIR overrides take effect; otherwise
+        # macOS (and any daemon-installed Linux) routes through the system
+        # daemon and writes into the host store.
+        "NIX_REMOTE": "",
+        # /tmp is a symlink to /private/tmp on macOS; without this nix refuses
+        # to use a store rooted under a symlinked path.
+        "NIX_IGNORE_SYMLINK_STORE": "1",
+    }
+    for var in ("NIX_USER_CONF_FILES", "NIX_PATH"):
+        env.pop(var, None)
+    Path(env["NIX_CONF_DIR"]).mkdir()
+    return env
+
+
+def _make_nix_runner(env: dict[str, str], cwd: Path):
+    def nix(*args: str, capture: bool = False) -> str:
+        cmd = ["nix", *_HERMETIC_NIX_OPTS, *args]
+        if capture:
+            return subprocess.check_output(cmd, cwd=cwd, env=env, text=True).strip()
+        subprocess.check_call(cmd, cwd=cwd, env=env)
+        return ""
+
+    return nix
+
+
+@contextlib.contextmanager
+def _http_server(directory: Path):
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(directory))
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+@pytest.mark.skipif(shutil.which("nix") is None, reason="requires nix CLI")
+@pytest.mark.parametrize("scheme", ["file", "http"])
+def test_fod_with_uncached_input_issue413(tmp_path: Path, scheme: str) -> None:
+    """An FOD whose output is in a substituter must report cacheStatus=cached,
+    even when its build-time-only input drv is absent from every substituter.
+    `nix build` would just download the FOD output and never invoke the input
+    builder.
+
+    Parametrised across the file:// and http:// substituter transports;
+    nix-eval-jobs uses querySubstitutablePathInfos in both cases (per-path,
+    no WantMassQuery gate), but the underlying store implementations differ.
+    """
+    env = _hermetic_nix_env(tmp_path)
+    assets = TEST_ROOT.joinpath("assets")
+    cache = tmp_path / "cache"
+    nix = _make_nix_runner(env, assets)
+
+    nix_system = nix("eval", "--impure", "--raw", "--expr", "builtins.currentSystem", capture=True)
+    flake_attr = f".#legacyPackages.{nix_system}.fodIssue413"
+
+    fod_out = nix("build", "--no-link", "--print-out-paths", f"{flake_attr}.fod", capture=True)
+
+    # Only the FOD output reaches the cache; the build input stays un-pushed.
+    nix("copy", "--to", f"file://{cache}", fod_out)
+    subprocess.check_call(["nix-collect-garbage", "-d"], env=env)
+
+    with contextlib.ExitStack() as stack:
+        if scheme == "file":
+            substituter = f"file://{cache}"
+        else:
+            substituter = stack.enter_context(_http_server(cache))
+        res = subprocess.check_output(
+            [
+                str(BIN),
+                "--gc-roots-dir",
+                str(tmp_path / "gc"),
+                *COMMON_FLAGS,
+                "--option",
+                "substituters",
+                substituter,
+                "--option",
+                "require-sigs",
+                "false",
+                "--check-cache-status",
+                "--flake",
+                flake_attr,
+            ],
+            cwd=assets,
+            env=env,
+            text=True,
+        )
+
+    jobs = [json.loads(line) for line in res.splitlines() if line]
+    fod = next(job for job in jobs if job["attr"] == "fod")
+    assert fod["cacheStatus"] == "cached", fod


### PR DESCRIPTION
queryMissing() walks input drvs and flags any whose output is missing from substituters as willBuild. For a fixed-output derivation whose build-time-only inputs are never pushed to a cache (a common CI shape: push FOD outputs, not their builders) every such FOD reports cacheStatus=notBuilt on every eval, even though `nix build` would just substitute the FOD output. CI dispatchers keying off cacheStatus then re-dispatch the lot.

Check output availability directly first and skip the input-drv walk when every output is already obtainable; fall through to queryMissing otherwise so its per-input neededBuilds breakdown still populates for unrealizable outputs (preserves #369). Uses querySubstitutablePathInfos rather than querySubstitutablePaths because the latter skips substituters lacking WantMassQuery, e.g. file://.

Fixes #413.