### PR TITLE
fix: register daemon-only settings before init

### DIFF
--- a/src/daemon-settings.cc
+++ b/src/daemon-settings.cc
@@ -10,6 +10,8 @@
 #include <nix/util/configuration.hh>
 #include <nix/util/types.hh>
 
+#include "daemon-settings.hh"
+
 namespace {
 
 struct DaemonSettings : nix::Config {
@@ -32,10 +34,18 @@ struct DaemonSettings : nix::Config {
         )"};
 };
 
-DaemonSettings
-    daemonSettings; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-// NOLINTNEXTLINE(cert-err58-cpp,cppcoreguidelines-avoid-non-const-global-variables)
-nix::GlobalConfig::Register rDaemonSettings(&daemonSettings);
-
 } // namespace
+
+namespace nix_eval_jobs {
+
+void registerDaemonSettings() {
+    // These must live for the process lifetime because GlobalConfig stores
+    // pointers to registered settings.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    static DaemonSettings daemonSettings;
+    // NOLINTNEXTLINE(cert-err58-cpp,cppcoreguidelines-avoid-non-const-global-variables)
+    static nix::GlobalConfig::Register const rDaemonSettings(&daemonSettings);
+    static_cast<void>(rDaemonSettings);
+}
+
+} // namespace nix_eval_jobs

--- a/src/daemon-settings.hh
+++ b/src/daemon-settings.hh
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace nix_eval_jobs {
+
+void registerDaemonSettings();
+
+} // namespace nix_eval_jobs

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -57,6 +57,7 @@
 #include "strings-portable.hh"
 #include "output-stream-lock.hh"
 #include "constituents.hh"
+#include "daemon-settings.hh"
 #include "store.hh"
 
 namespace {
@@ -521,6 +522,7 @@ auto main(int argc, char **argv) -> int {
     auto args = std::span(argv, argc);
 
     return nix::handleExceptions(args[0], [&]() -> void {
+        nix_eval_jobs::registerDaemonSettings();
         nix::initNix();
         nix::initGC();
         nix::flakeSettings.configureEvalSettings(nix::evalSettings);

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -158,6 +158,26 @@ def test_no_gcroot_dir() -> None:
     assert "this is an evaluation error" in attrs["error"]
 
 
+def test_daemon_only_settings_do_not_warn(tmp_path: Path) -> None:
+    nix_conf_dir = tmp_path / "nix-conf"
+    nix_conf_dir.mkdir()
+    nix_conf_dir.joinpath("nix.conf").write_text("allowed-users = *\ntrusted-users = root @admin\n")
+
+    env = os.environ.copy()
+    env["NIX_CONF_DIR"] = str(nix_conf_dir)
+
+    res = subprocess.run(
+        [str(BIN), "--expr", "42"],
+        cwd=TEST_ROOT.joinpath("assets"),
+        env=env,
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+
+    assert "warning:" not in res.stderr
+
+
 def test_constituents() -> None:
     with TemporaryDirectory() as tempdir:
         cmd = [


### PR DESCRIPTION
PR #398 added dummy daemon-only settings to silence warnings for daemon
config keys such as allowed-users and trusted-users, but the
implementation depended on a static initializer in daemon-settings.cc.

That translation unit is part of a static library and the final
executable did not reference any symbol from it, so the linker could
omit the object file. When that happened, the GlobalConfig registration
never ran before nix::initNix() read nix.conf, and the warnings
remained.

Expose an explicit registerDaemonSettings() function and call it from
main before nix::initNix(). This both forces the object file into the
executable and makes the registration order deterministic. Add a
functional regression test that loads a nix.conf containing
allowed-users and trusted-users and asserts no warnings are emitted.

Fixes: #411
