### PR TITLE
resolve cache status asynchronously off the eval workers

### DIFF
--- a/src/cache-status-resolver.cc
+++ b/src/cache-status-resolver.cc
@@ -1,0 +1,276 @@
+#include <algorithm>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp> // IWYU pragma: keep
+#include <boost/asio/executor_work_guard.hpp>
+#include <exception>
+#include <map>
+#include <mutex>
+#include <nix/store/derivations.hh>
+#include <nix/store/path-info.hh>
+#include <nix/store/path.hh>
+#include <nix/store/store-api.hh>
+#include <nix/store/store-open.hh>
+#include <nix/util/async.hh>
+#include <nix/util/callback.hh>
+#include <nix/util/error.hh>
+#include <nix/util/ref.hh>
+#include <nix/util/signals.hh>
+#include <nix/util/types.hh>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "cache-status-resolver.hh"
+#include "drv.hh"
+#include "response.hh"
+
+namespace asio = boost::asio;
+
+namespace {
+
+/* Deterministic output order: by name, then full path (matches the
+   previous queryMissing-based implementation). */
+void sortPaths(std::vector<nix::StorePath> &paths) {
+    std::ranges::sort(
+        paths,
+        [](const nix::StorePath &lhs, const nix::StorePath &rhs) -> bool {
+            return lhs.name() != rhs.name() ? lhs.name() < rhs.name()
+                                            : lhs.to_string() < rhs.to_string();
+        });
+}
+
+} // namespace
+
+CacheStatusResolver::CacheStatusResolver(nix::ref<nix::Store> store, Sink sink)
+    : store(std::move(store)), substituters(nix::getDefaultSubstituters()),
+      sink(std::move(sink)), workGuard(asio::make_work_guard(ctx)) {
+    ioThread = std::thread([this]() -> void { ctx.run(); });
+}
+
+void CacheStatusResolver::stopAndJoin() {
+    workGuard.reset();
+    if (ioThread.joinable()) {
+        ioThread.join();
+    }
+}
+
+CacheStatusResolver::~CacheStatusResolver() {
+    {
+        const std::scoped_lock lock(mutex);
+        closed = true;
+    }
+    // The destructor runs on error paths (exception unwinding) where
+    // draining the backlog would only delay shutdown. Stopping the
+    // io_context would be unsafe: in-flight FileTransfer callbacks
+    // post their completion to it from the curl thread (see
+    // callbackToAwaitable). Instead `aborted` makes every coroutine
+    // bail out right after its current await.
+    aborted = true;
+    stopAndJoin();
+}
+
+void CacheStatusResolver::push(Response response) {
+    {
+        const std::scoped_lock lock(mutex);
+        // Drop new work after close or a failure: finish() rethrows
+        // the failure anyway, more lookups would be wasted work.
+        if (closed || exc) {
+            return;
+        }
+        inFlight++;
+    }
+    // NOLINTNEXTLINE(misc-include-cleaner): provided by co_spawn.hpp
+    asio::co_spawn(
+        ctx, process(std::move(response)),
+        [this](const std::exception_ptr &error) -> void { onJobDone(error); });
+}
+
+void CacheStatusResolver::finish() {
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        closed = true;
+        idle.wait(lock, [this]() -> bool { return inFlight == 0; });
+    }
+    stopAndJoin();
+    const std::scoped_lock lock(mutex);
+    if (exc) {
+        std::rethrow_exception(exc);
+    }
+}
+
+void CacheStatusResolver::onJobDone(const std::exception_ptr &error) {
+    const std::scoped_lock lock(mutex);
+    inFlight--;
+    if (error && !exc) {
+        exc = error;
+        aborted = true;
+    }
+    if (inFlight == 0) {
+        idle.notify_all();
+    }
+}
+
+void CacheStatusResolver::throwIfAborted() const {
+    nix::checkInterrupt();
+    if (aborted) {
+        throw nix::Error("cache-status lookup aborted");
+    }
+}
+
+// Coroutine parameters are by value: references can dangle across
+// suspension points.
+auto CacheStatusResolver::substitutable(nix::StorePath path)
+    -> asio::awaitable<bool> {
+    throwIfAborted();
+    if (auto cached = probeCache.find(path); cached != probeCache.end()) {
+        co_return cached->second;
+    }
+    bool found = false;
+    for (const auto &sub : substituters) {
+        if (sub->storeDir != store->storeDir) {
+            continue;
+        }
+        try {
+            co_await nix::callbackToAwaitable<
+                nix::ref<const nix::ValidPathInfo>>(
+                [&](nix::Callback<nix::ref<const nix::ValidPathInfo>> callback)
+                    -> void { sub->queryPathInfo(path, std::move(callback)); });
+            found = true;
+            break;
+            // NOLINTNEXTLINE(bugprone-empty-catch)
+        } catch (nix::InvalidPath &) {
+            // not in this substituter
+            // NOLINTNEXTLINE(bugprone-empty-catch)
+        } catch (nix::Error &) {
+            // unreachable/misconfigured substituter; queryMissing
+            // also treats these as misses
+        }
+    }
+    probeCache.emplace(path, found);
+    co_return found;
+}
+
+auto CacheStatusResolver::allSubstitutable(std::vector<nix::StorePath> paths)
+    -> asio::awaitable<bool> {
+    for (const auto &path : paths) {
+        if (!co_await substitutable(path)) {
+            co_return false;
+        }
+    }
+    co_return true;
+}
+
+/* The wanted (or all, when wantedOutputs is empty) output paths of a
+   derivation that are not in the local store; nullopt when an output
+   path is statically unknown (CA derivations). */
+auto CacheStatusResolver::missingOutputs(const nix::Derivation &derivation,
+                                         const nix::StringSet &wantedOutputs)
+    -> std::optional<std::vector<nix::StorePath>> {
+    std::vector<nix::StorePath> missing;
+    for (const auto &[outputName, outputPathOpt] :
+         derivation.outputsAndOptPaths(*store)) {
+        if (!wantedOutputs.empty() && !wantedOutputs.contains(outputName)) {
+            continue;
+        }
+        if (!outputPathOpt.second) {
+            return std::nullopt;
+        }
+        if (!store->isValidPath(*outputPathOpt.second)) {
+            missing.push_back(*outputPathOpt.second);
+        }
+    }
+    return missing;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion): walking a DAG of derivations
+auto CacheStatusResolver::visitDrv(Traversal *traversal, nix::StorePath drvPath,
+                                   nix::StringSet wantedOutputs)
+    -> asio::awaitable<void> {
+    throwIfAborted();
+    if (!traversal->visited.insert(drvPath).second) {
+        co_return;
+    }
+    auto derivation = store->readDerivation(drvPath);
+
+    auto missing = missingOutputs(derivation, wantedOutputs);
+    if (!missing) {
+        traversal->drv.unknownPaths.push_back(drvPath);
+        co_return;
+    }
+    if (missing->empty()) {
+        co_return;
+    }
+
+    if (co_await allSubstitutable(*missing)) {
+        // Unlike queryMissing we do not walk the references of
+        // substitutable paths, so neededSubstitutes lists drv
+        // outputs only, not their transitive closure.
+        traversal->substitutePaths.insert(missing->begin(), missing->end());
+        co_return;
+    }
+
+    for (const auto &[inputDrvPath, inputNode] : derivation.inputDrvs.map) {
+        co_await visitDrv(traversal, inputDrvPath, inputNode.value);
+    }
+    /* Post-order: dependencies are appended before their dependants,
+       matching the reversed topological sort of the queryMissing-based
+       implementation. */
+    traversal->drv.neededBuilds.push_back(drvPath);
+}
+
+auto CacheStatusResolver::process(Response response) -> asio::awaitable<void> {
+    nix::checkInterrupt();
+    if (aborted) {
+        co_return;
+    }
+
+    auto *job = std::get_if<Response::Job>(&response.payload);
+    if (job == nullptr) {
+        sink(std::move(response));
+        co_return;
+    }
+    auto &drv = job->drv;
+
+    /* Fast path: all output paths are statically known, so the drv is
+       obtainable iff every missing output is substitutable. This
+       mirrors checkOutputsAvailable and avoids walking the inputs of
+       FODs whose build-time-only deps are not cached (issue #413). */
+    std::vector<nix::StorePath> missingJobOutputs;
+    bool outputsKnown = true;
+    for (const auto &[outputName, outputPath] : drv.outputs) {
+        if (!outputPath) {
+            outputsKnown = false;
+            break;
+        }
+        if (!store->isValidPath(*outputPath)) {
+            missingJobOutputs.push_back(*outputPath);
+        }
+    }
+
+    if (outputsKnown) {
+        if (co_await allSubstitutable(missingJobOutputs)) {
+            drv.neededSubstitutes = missingJobOutputs;
+            sortPaths(drv.neededSubstitutes);
+            drv.cacheStatus = missingJobOutputs.empty()
+                                  ? Drv::CacheStatus::Local
+                                  : Drv::CacheStatus::Cached;
+            sink(std::move(response));
+            co_return;
+        }
+    }
+
+    /* Slow path: something needs building. Walk the input graph for
+       the per-derivation breakdown (which inputs will build, which
+       come from a cache), like Store::queryMissing. */
+    Traversal traversal{.drv = drv, .visited = {}, .substitutePaths = {}};
+    co_await visitDrv(&traversal, drv.drvPath, {});
+
+    drv.neededSubstitutes.assign(traversal.substitutePaths.begin(),
+                                 traversal.substitutePaths.end());
+    sortPaths(drv.neededSubstitutes);
+    drv.cacheStatus = Drv::CacheStatus::NotBuilt;
+    sink(std::move(response));
+}

--- a/src/cache-status-resolver.hh
+++ b/src/cache-status-resolver.hh
@@ -1,0 +1,105 @@
+#pragma once
+///@file
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <exception>
+#include <functional>
+#include <list>
+#include <map>
+#include <mutex>
+#include <nix/store/derivations.hh>
+#include <nix/store/path.hh>
+#include <optional>
+#include <nix/store/store-api.hh>
+#include <nix/util/types.hh>
+#include <set>
+#include <nix/util/ref.hh>
+#include <thread>
+#include <vector>
+
+#include "drv.hh"
+#include "response.hh"
+
+/* Resolves the cache status (substituter narinfo lookups) of evaluated
+   jobs with asio coroutines on a single io thread.
+
+   Doing the lookup inline in the eval worker stalls CPU-bound
+   evaluation behind HTTP round-trips, so the collector hands
+   finished jobs over to this resolver instead. The probes use the
+   store's asynchronous
+   queryPathInfo, so one thread suffices to keep many lookups in
+   flight. */
+class CacheStatusResolver {
+  public:
+    /* Called with the job after its cache status has been filled in.
+       Invoked from the io thread; the sink must do its own locking. */
+    using Sink = std::function<void(Response)>;
+
+    CacheStatusResolver(nix::ref<nix::Store> store, Sink sink);
+    ~CacheStatusResolver();
+
+    CacheStatusResolver(const CacheStatusResolver &) = delete;
+    CacheStatusResolver(CacheStatusResolver &&) = delete;
+    auto operator=(const CacheStatusResolver &)
+        -> CacheStatusResolver & = delete;
+    auto operator=(CacheStatusResolver &&) -> CacheStatusResolver & = delete;
+
+    void push(Response response);
+
+    /* Drain remaining work, stop the io thread and rethrow the first
+       error raised by a job. */
+    void finish();
+
+  private:
+    /* Per-job state of the slow-path input graph walk. */
+    struct Traversal {
+        Drv &drv;
+        nix::StorePathSet visited;
+        std::set<nix::StorePath> substitutePaths;
+    };
+
+    auto process(Response response) -> boost::asio::awaitable<void>;
+    auto visitDrv(Traversal *traversal, nix::StorePath drvPath,
+                  nix::StringSet wantedOutputs) -> boost::asio::awaitable<void>;
+    auto missingOutputs(const nix::Derivation &derivation,
+                        const nix::StringSet &wantedOutputs)
+        -> std::optional<std::vector<nix::StorePath>>;
+    auto substitutable(nix::StorePath path) -> boost::asio::awaitable<bool>;
+    auto allSubstitutable(std::vector<nix::StorePath> paths)
+        -> boost::asio::awaitable<bool>;
+    void throwIfAborted() const;
+    void onJobDone(const std::exception_ptr &error);
+    void stopAndJoin();
+
+    nix::ref<nix::Store> store;
+    std::list<nix::ref<nix::Store>> substituters;
+    Sink sink;
+
+    boost::asio::io_context ctx;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+        workGuard;
+    std::thread ioThread;
+
+    /* Concurrency is bounded by nix's own http-connections limit per
+       substituter, so jobs are spawned as they arrive; there is no
+       in-flight cap of our own. */
+    std::mutex mutex;
+    std::condition_variable idle;
+    size_t inFlight = 0;
+    bool closed = false;
+    std::exception_ptr exc;
+    /* Cooperative cancellation, checked by the coroutines between
+       awaits. Atomic because the destructor sets it from another
+       thread without holding the mutex. */
+    std::atomic<bool> aborted = false;
+
+    /* Jobs share most of their closure (e.g. stdenv), so remember
+       per-path probe results across jobs. Only ever touched from the
+       io thread. */
+    std::map<nix::StorePath, bool> probeCache;
+};

--- a/src/drv.cc
+++ b/src/drv.cc
@@ -31,7 +31,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <algorithm>
 
 #include "drv.hh"
 #include "eval-args.hh"
@@ -106,122 +105,6 @@ auto queryInputDrvs(const nix::Derivation &drv)
     return drvs;
 }
 
-// queryMissing's per-input traversal flags an FOD as willBuild whenever a
-// build-time-only input is missing from substituters, even though `nix build`
-// would just download the FOD's own output. Returns Local/Cached when every
-// output is already obtainable; nullopt means the caller should fall through
-// to queryMissing so its per-input breakdown still populates neededBuilds for
-// cross-system jobs (issue #369).
-auto checkOutputsAvailable(
-    nix::Store &store,
-    std::map<std::string, std::optional<nix::StorePath>> &outputs,
-    std::vector<nix::StorePath> &neededSubstitutes)
-    -> std::optional<Drv::CacheStatus> {
-    nix::StorePathCAMap toQuery;
-    for (auto const &[outputName, outputPath] : outputs) {
-        if (!outputPath) {
-            return std::nullopt;
-        }
-        if (!store.isValidPath(*outputPath)) {
-            toQuery.insert({*outputPath, std::nullopt});
-        }
-    }
-    nix::SubstitutablePathInfos infos;
-    if (!toQuery.empty()) {
-        store.querySubstitutablePathInfos(toQuery, infos);
-    }
-    if (infos.size() != toQuery.size()) {
-        return std::nullopt;
-    }
-    for (auto const &[path, info] : infos) {
-        neededSubstitutes.push_back(path);
-    }
-    std::ranges::sort(
-        neededSubstitutes,
-        [](const nix::StorePath &lhs, const nix::StorePath &rhs) -> bool {
-            return lhs.name() != rhs.name() ? lhs.name() < rhs.name()
-                                            : lhs.to_string() < rhs.to_string();
-        });
-    return infos.empty() ? Drv::CacheStatus::Local : Drv::CacheStatus::Cached;
-}
-
-auto queryCacheStatus(
-    nix::Store &store,
-    std::map<std::string, std::optional<nix::StorePath>> &outputs,
-    nix::StorePaths &neededBuilds,
-    std::vector<nix::StorePath> &neededSubstitutes,
-    std::vector<nix::StorePath> &unknownPaths, const nix::Derivation &drv)
-    -> Drv::CacheStatus {
-
-    if (auto cached =
-            checkOutputsAvailable(store, outputs, neededSubstitutes)) {
-        return *cached;
-    }
-
-    std::vector<nix::StorePathWithOutputs> paths;
-    for (auto const &[key, val] : outputs) {
-        if (val) {
-            paths.push_back(nix::StorePathWithOutputs{*val, {}});
-        }
-    }
-    // Input drvs go in too so neededBuilds is populated for cross-system jobs
-    // whose own output paths are unknown (issue #369).
-    for (const auto &[inputDrvPath, inputNode] : drv.inputDrvs.map) {
-        paths.push_back(
-            nix::StorePathWithOutputs(inputDrvPath, inputNode.value));
-    }
-
-    auto missing = store.queryMissing(toDerivedPaths(paths));
-
-    if (!missing.willBuild.empty()) {
-        // TODO: can we expose the topological sort order as a graph?
-        auto sorted = store.topoSortPaths(missing.willBuild);
-        std::ranges::reverse(sorted.begin(), sorted.end());
-        for (auto &path : sorted) {
-            neededBuilds.push_back(std::move(path));
-        }
-    }
-    if (!missing.willSubstitute.empty()) {
-        std::vector<const nix::StorePath *> willSubstituteSorted = {};
-        std::ranges::for_each(missing.willSubstitute.begin(),
-                              missing.willSubstitute.end(),
-                              [&](const nix::StorePath &path) -> void {
-                                  willSubstituteSorted.push_back(&path);
-                              });
-        std::ranges::sort(
-            willSubstituteSorted.begin(), willSubstituteSorted.end(),
-            [](const nix::StorePath *lhs, const nix::StorePath *rhs) -> bool {
-                if (lhs->name() == rhs->name()) {
-                    return lhs->to_string() < rhs->to_string();
-                }
-                return lhs->name() < rhs->name();
-            });
-        for (const auto *path : willSubstituteSorted) {
-            neededSubstitutes.push_back(*path);
-        }
-    }
-
-    if (!missing.unknown.empty()) {
-        for (const auto &path : missing.unknown) {
-            unknownPaths.push_back(path);
-        }
-    }
-
-    if (missing.willBuild.empty() && missing.unknown.empty()) {
-        if (missing.willSubstitute.empty()) {
-            // cacheStatus is Local if:
-            //  - there's nothing to build
-            //  - there's nothing to substitute
-            return Drv::CacheStatus::Local;
-        }
-        // cacheStatus is Cached if:
-        //  - there's nothing to build
-        //  - there are paths to substitute
-        return Drv::CacheStatus::Cached;
-    }
-    return Drv::CacheStatus::NotBuilt;
-};
-
 } // namespace
 
 /* The fields of a derivation that are printed in json form */
@@ -253,13 +136,6 @@ auto Drv::fromPackageInfo(std::string &attrPath, nix::EvalState &state,
 
         // Use the more precise system from the derivation
         result.system = drv.platform;
-
-        if (args.checkCacheStatus) {
-            // TODO: is this a bottleneck, where we should batch these queries?
-            result.cacheStatus = queryCacheStatus(
-                *store, result.outputs, result.neededBuilds,
-                result.neededSubstitutes, result.unknownPaths, drv);
-        }
 
         if (args.showInputDrvs) {
             result.inputDrvs = queryInputDrvs(drv);

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ common_src = [
   'worker.cc',
   'strings-portable.cc',
   'output-stream-lock.cc',
+  'cache-status-resolver.cc',
   'daemon-settings.cc'
 ]
 

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -64,6 +64,7 @@
 #include "constituents.hh"
 #include "daemon-settings.hh"
 #include "store.hh"
+#include "cache-status-resolver.hh"
 
 namespace {
 MyArgs myArgs; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -359,9 +360,30 @@ auto getNextJob(nix::Sync<State> &state_, std::condition_variable &wakeup)
     }
 }
 
+/* Record a finished job/error in the shared state and print it,
+   unless it is an aggregate that still awaits its constituents (then
+   handleConstituents prints it later). */
+void emitResponse(nix::Sync<State> &state_, const Response &response,
+                  nlohmann::json jsonResponse, std::string_view dumped) {
+    {
+        auto state(state_.lock());
+        state->jobs.insert_or_assign(response.attr, std::move(jsonResponse));
+    }
+
+    bool hasPendingConstituents = false;
+    if (const auto *job = std::get_if<Response::Job>(&response.payload)) {
+        hasPendingConstituents =
+            !job->drv.constituents.namedConstituents.empty();
+    }
+    if (!hasPendingConstituents) {
+        getCoutLock().lock() << dumped << "\n";
+    }
+}
+
 auto processWorkerResponse(LineReader *fromReader,
                            const nlohmann::json &attrPath, Proc *proc,
-                           nix::Sync<State> &state_)
+                           nix::Sync<State> &state_,
+                           CacheStatusResolver *cacheStatusResolver)
     -> std::vector<nlohmann::json> {
     // Read response from worker
     auto respString = fromReader->readLine();
@@ -389,22 +411,13 @@ auto processWorkerResponse(LineReader *fromReader,
             newAttr.emplace_back(attr);
             newAttrs.push_back(newAttr);
         }
+    } else if ((cacheStatusResolver != nullptr) &&
+               std::holds_alternative<Response::Job>(response.payload)) {
+        // The resolver fills in cacheStatus, then records/prints the job
+        // via its sink.
+        cacheStatusResolver->push(std::move(response));
     } else {
-        {
-            auto state(state_.lock());
-            state->jobs.insert_or_assign(response.attr,
-                                         std::move(jsonResponse));
-        }
-
-        bool hasPendingConstituents = false;
-        if (auto *job = std::get_if<Response::Job>(&response.payload)) {
-            hasPendingConstituents =
-                !job->drv.constituents.namedConstituents.empty();
-        }
-
-        if (!hasPendingConstituents) {
-            getCoutLock().lock() << respString << "\n";
-        }
+        emitResponse(state_, response, std::move(jsonResponse), respString);
 
         if (auto *error = std::get_if<Response::Error>(&response.payload);
             (error != nullptr) && error->fatal) {
@@ -427,7 +440,23 @@ void updateJobQueue(nix::Sync<State> &state_, std::condition_variable &wakeup,
 }
 } // namespace
 
-void collector(nix::Sync<State> &state_, std::condition_variable &wakeup) {
+/* Rationale for the separate resolver: see CacheStatusResolver. */
+auto makeCacheStatusResolver(const MyArgs &args, nix::Sync<State> &state_)
+    -> std::optional<CacheStatusResolver> {
+    if (!args.checkCacheStatus) {
+        return std::nullopt;
+    }
+    return std::optional<CacheStatusResolver>(
+        std::in_place, nix_eval_jobs::openStore(args.evalStoreUrl),
+        [&state_](const Response &response) -> void {
+            nlohmann::json jsonResponse = response;
+            auto dumped = jsonResponse.dump();
+            emitResponse(state_, response, std::move(jsonResponse), dumped);
+        });
+}
+
+void collector(nix::Sync<State> &state_, std::condition_variable &wakeup,
+               CacheStatusResolver *cacheStatusResolver) {
     try {
         std::unique_ptr<Proc> proc;
         std::unique_ptr<LineReader> fromReader;
@@ -463,8 +492,9 @@ void collector(nix::Sync<State> &state_, std::condition_variable &wakeup) {
                 handleBrokenWorkerPipe(*proc, msg);
             }
 
-            auto newAttrs = processWorkerResponse(fromReader.get(), attrPath,
-                                                  proc.get(), state_);
+            auto newAttrs =
+                processWorkerResponse(fromReader.get(), attrPath, proc.get(),
+                                      state_, cacheStatusResolver);
 
             updateJobQueue(state_, wakeup, attrPath, newAttrs);
         }
@@ -589,24 +619,43 @@ auto main(int argc, char **argv) -> int {
            fail with "unable to open database file". Open it once here. */
         nix::fetchSettings.getCache();
 
+        auto cacheStatusResolver = makeCacheStatusResolver(myArgs, state_);
+        auto *cacheStatusResolverPtr =
+            cacheStatusResolver ? &*cacheStatusResolver : nullptr;
+
         /* Start a collector thread per worker process. */
         std::vector<Thread> threads;
         std::condition_variable wakeup;
         threads.reserve(myArgs.nrWorkers);
         for (size_t i = 0; i < myArgs.nrWorkers; i++) {
             threads.emplace_back(
-                [&state_, &wakeup] -> void { collector(state_, wakeup); });
+                [&state_, &wakeup, cacheStatusResolverPtr] -> void {
+                    collector(state_, wakeup, cacheStatusResolverPtr);
+                });
         }
 
         for (auto &thread : threads) {
             thread.join();
         }
 
-        auto state(state_.lock());
-
-        if (state->exc) {
-            std::rethrow_exception(state->exc);
+        /* A collector error must surface immediately: rethrowing it
+           here lets the CacheStatusResolver destructor discard the
+           backlog instead of finish() draining it first (which would
+           also mask the eval error with any resolver error). */
+        {
+            auto state(state_.lock());
+            if (state->exc) {
+                std::rethrow_exception(state->exc);
+            }
         }
+
+        /* All eval results are in; wait for outstanding cache-status
+           checks before constituents are aggregated. */
+        if (cacheStatusResolver) {
+            cacheStatusResolver->finish();
+        }
+
+        auto state(state_.lock());
 
         if (myArgs.constituents) {
             handleConstituents(state->jobs, myArgs);

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -47,23 +47,21 @@ def common_test(extra_args: list[str]) -> list[dict[str, Any]]:
         results = [json.loads(r) for r in res.stdout.split("\n") if r]
         assert len(results) == 4
 
-        built_job = results[0]
-        assert built_job["attr"] == "builtJob"
+        by_attr = {r["attr"]: r for r in results}
+
+        built_job = by_attr["builtJob"]
         assert built_job["name"] == "job1"
         assert built_job["outputs"]["out"].endswith("-job1")
         assert built_job["drvPath"].endswith(".drv")
         # No meta field in bare derivations
 
-        dotted_job = results[1]
-        assert dotted_job["attr"] == '"dotted.attr"'
+        dotted_job = by_attr['"dotted.attr"']
         assert dotted_job["attrPath"] == ["dotted.attr"]
 
-        package_with_deps = results[2]
-        assert package_with_deps["attr"] == "package-with-deps"
+        package_with_deps = by_attr["package-with-deps"]
         assert package_with_deps["name"] == "package-with-deps"
 
-        recurse_drv = results[3]
-        assert recurse_drv["attr"] == "recurse.drvB"
+        recurse_drv = by_attr["recurse.drvB"]
         assert recurse_drv["name"] == "drvB"
 
         assert len(list(Path(tempdir).iterdir())) == 4


### PR DESCRIPTION
With `--check-cache-status` each eval worker runs the substituter narinfo lookups inline: evaluation is CPU-bound, the lookups are network-bound, and each worker blocks on HTTP round-trips between attrs. I measured for 50k-attribute flake, an eval speed of ~16-19 derivations / s for otherwise trivial derivations.

The fix is to move to the new Nix boost asio coroutines.

500 negative narinfo lookups against four substituters, fresh narinfo caches, private chroot store:

| variant | time |
|---|---|
| inline in eval workers (before) | ~57s |
| 64-thread pool (earlier revision of this PR) | ~3-5s |
| asio coroutines, 1 io thread (this PR) | ~3-5s |

### Merge blocker
The first commit bumps the nix input to master: `nix/util/async.hh` is not in 2.34. Wait for a nix release containing it, then replace the bump commit with the release branch.