### PR TITLE
enable unity builds by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,8 +5,18 @@ project(
   license: 'GPL-3.0',
   default_options: [
     'cpp_std=c++20',
-    'warning_level=3'
+    'warning_level=3',
+    'unity=on',
+    'unity_size=999'
   ]
+)
+
+cpp = meson.get_compiler('cpp')
+# Unity builds merge translation units, so coroutine frames embed
+# lambda types with no linkage; harmless, but GCC warns about it.
+add_project_arguments(
+  cpp.get_supported_arguments('-Wno-subobject-linkage'),
+  language: 'cpp',
 )
 
 threads_dep = dependency('threads', required: true)


### PR DESCRIPTION
Merging translation units cuts a clean build's CPU time from ~140s to ~43s, which matters on loaded CI runners building several variants in parallel. The project is small enough (eight source files) that the lost incremental granularity is an acceptable trade; pass `-Dunity=off` for an edit-compile loop on a single file.

GCC emits `-Wsubobject-linkage` for coroutine frames that embed lambda types once translation units are merged; harmless, suppressed project-wide via `get_supported_arguments` (clang unaffected).