### PR TITLE
tests: skip test_fod_with_uncached_input_issue413 on macOS

### DIFF
--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -7,6 +7,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import threading
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -686,6 +687,15 @@ def _http_server(directory: Path):
 
 
 @pytest.mark.skipif(shutil.which("nix") is None, reason="requires nix CLI")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason=(
+        "needs a real nested `nix build`; on macOS Nix still configures a "
+        "sandbox-exec profile even with sandbox=false, which cannot be nested "
+        "inside the functional-tests build sandbox "
+        "(sandbox initialization failed: Operation not permitted)"
+    ),
+)
 @pytest.mark.parametrize("scheme", ["file", "http"])
 def test_fod_with_uncached_input_issue413(tmp_path: Path, scheme: str) -> None:
     """An FOD whose output is in a substituter must report cacheStatus=cached,


### PR DESCRIPTION
This fixes a `nix flake check` failure on macOS, as seen here: https://github.com/DeterminateSystems/nix-eval-jobs/actions/runs/27219083796/job/80530442558

```
nix-eval-jobs-functional-tests> error:
nix-eval-jobs-functional-tests>        … while waiting for the build environment for '/nix/var/nix/builds/nix-2183-3905262493/pytest-of-_nixbld1/pytest-0/test_fod_with_uncached_input_i1/store/2ax8r4h4wfwshdihxz260aayk1wx3sy6-never-cached.drv' to initialize (failed with exit code 1, previous messages: sandbox initialization failed: Operation not permitted|failed to configure sandbox: Operation not permitted)
nix-eval-jobs-functional-tests> 
nix-eval-jobs-functional-tests>        error: unexpected EOF reading a line
```

Running `sandbox-exec` inside a sandboxed build does not currently work, so just skip that test. 

I guess the underlying problem is that Nix always uses `sandbox-exec` even when sandboxing is disabled. We should probably add a way to really disable sandboxing.