### PR TITLE
pre-initialize fetcher cache before spawning workers

### DIFF
--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -18,6 +18,7 @@
 #include <memory>
 #include <nix/cmd/common-eval-args.hh>
 #include <nix/expr/eval-gc.hh>
+#include <nix/fetchers/fetch-settings.hh>
 #include <nix/expr/eval-settings.hh>
 #include <nix/expr/eval.hh> // NOLINT(misc-header-include-cycle)
 #include <nix/flake/flake.hh>
@@ -591,6 +592,11 @@ auto main(int argc, char **argv) -> int {
         if (myArgs.evalStoreUrl.has_value()) {
             nix_eval_jobs::openStore(myArgs.evalStoreUrl);
         }
+
+        /* The fetcher cache is opened lazily on first fetch, so forked
+           workers would otherwise race to create fetcher-cache-v4.sqlite and
+           fail with "unable to open database file". Open it once here. */
+        nix::fetchSettings.getCache();
 
         /* Start a collector thread per worker process. */
         std::vector<Thread> threads;


### PR DESCRIPTION

The fetcher cache (fetcher-cache-v4.sqlite) is opened lazily on the
first fetch. With multiple workers, the forked processes race to create
the SQLite database and fail with 'unable to open database file'.

Open the cache once in the parent so the file and schema are created
before any worker forks, mirroring the existing eval-store pre-init.
