### PR TITLE
release 2.34.3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  revision = "2";
+  revision = "3";
 in
 stdenv.mkDerivation {
   pname = "nix-eval-jobs";


### PR DESCRIPTION

Bump revision so the version derived from nix 2.34.1 becomes 2.34.3,
shipping the fetcher-cache startup-race fix.
