### PR TITLE
Convert MaxRSS from bytes to KiB on macOS

### DIFF
--- a/src/worker.cc
+++ b/src/worker.cc
@@ -309,10 +309,13 @@ auto initializeRootValue(const nix::ref<nix::EvalState> &state,
 auto shouldRestart(const MyArgs &args) -> bool {
     struct rusage resourceUsage = {}; // NOLINT(misc-include-cleaner)
     getrusage(RUSAGE_SELF, &resourceUsage);
-    const size_t maxrss =
+    size_t maxrss =
         resourceUsage
             .ru_maxrss; // NOLINT(cppcoreguidelines-pro-type-union-access)
     static constexpr size_t KB_TO_BYTES = 1024;
+#ifdef __APPLE__
+    maxrss /= KB_TO_BYTES; // ru_maxrss is bytes on macOS instead of KiB
+#endif
     return maxrss > args.maxMemorySize * KB_TO_BYTES;
 }
 


### PR DESCRIPTION
Fixes #425 by changing the interpretation of the `--max-memory-size` value (including its default of 4096 MiB) from incorrectly being KiB on macOS to correctly being MiB like it already is on Linux. With a default of only 4 MiB, workers get killed way more often than they should, causing two orders of magnitude of slowdown.

https://github.com/NixOS/nix-eval-jobs/blob/4b56d787e5add67e8f732365a60f590e3efdd5bc/src/eval-args.hh#L18

Relevant man page for `ru_maxrss` on macOS: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.121.6/bsd/man/man2/getrusage.2#L94-L95

> the maximum resident set size utilized (in bytes).

See libuv/libuv#3721 for another past example of this same bug in a different project.