### PR TITLE
Update to fix compat issues with Nix 2.35

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,16 +23,16 @@
     "nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1772966630,
-        "narHash": "sha256-qzVtneydMSjNZXzNbxQG9VvJc490keS9RNlbUCfiQas=",
+        "lastModified": 1783987836,
+        "narHash": "sha256-UkRzz0meYeuSQt5rQodwfiSe1If+5JojDP7Kxk0beXM=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "26842787496f2293c676fb36db38dacfd63497e0",
+        "rev": "aa2613fa02ca6199fe0ebf61a0f7f6d781d32a47",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "2.34-maintenance",
+        "ref": "2.35-maintenance",
         "repo": "nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs.nixpkgs.url = "https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz";
   inputs.nix = {
-    url = "github:NixOS/nix/2.34-maintenance";
+    url = "github:NixOS/nix/2.35-maintenance";
     # We want to control the deps precisely
     flake = false;
   };

--- a/src/nix-eval-jobs.cc
+++ b/src/nix-eval-jobs.cc
@@ -37,7 +37,6 @@
 #include <nix/util/terminal.hh>
 #include <nix/util/util.hh>
 #ifdef __linux__
-#include <sched.h>
 #include <nix/util/linux-namespaces.hh>
 #include <nix/util/users.hh>
 #endif
@@ -538,10 +537,7 @@ auto main(int argc, char **argv) -> int {
            from stripping ro/nosuid/nodev on the host's /nix/store mount. */
         if (nix::isRootUser()) {
             try {
-                nix::saveMountNamespace();
-                if (unshare(CLONE_NEWNS) == -1) {
-                    throw nix::SysError("setting up a private mount namespace");
-                }
+                nix::tryEnterPrivateMountNamespace();
             } catch (nix::Error &e) {
                 nix::warn("failed to set up a private mount namespace: %s",
                           e.msg());


### PR DESCRIPTION
Nix 2.35 removed `saveMountNamespace()`; its replacement, `tryEnterPrivateMountNamespace()`, performs both the parent-namespace save and the `unshare(CLONE_NEWNS)` call, so the manual unshare and the `<sched.h>` include are dropped.