### PR TITLE
release 2.35.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  revision = "3";
+  revision = "0";
 in
 stdenv.mkDerivation {
   pname = "nix-eval-jobs";


### PR DESCRIPTION
Bump revision for the Nix 2.35 update and recent collector/cache-status
changes so downstreams get a tagged version matching the new Nix
maintenance branch.
