### PR TITLE
avoid inheriting FileTransfer across evaluator forks

### DIFF
--- a/src/cache-status-resolver.cc
+++ b/src/cache-status-resolver.cc
@@ -6,6 +6,9 @@
 #include <map>
 #include <mutex>
 #include <nix/store/derivations.hh>
+#include <nix/store/filetransfer.hh>
+#include <nix/store/globals.hh>
+#include <nix/store/http-binary-cache-store.hh>
 #include <nix/store/path-info.hh>
 #include <nix/store/path.hh>
 #include <nix/store/store-api.hh>
@@ -13,6 +16,7 @@
 #include <nix/util/async.hh>
 #include <nix/util/callback.hh>
 #include <nix/util/error.hh>
+#include <nix/util/logging.hh>
 #include <nix/util/ref.hh>
 #include <nix/util/signals.hh>
 #include <nix/util/types.hh>
@@ -31,6 +35,45 @@ namespace asio = boost::asio;
 
 namespace {
 
+/* Opening an HTTP store normally uses Nix's process-global FileTransfer.
+   CacheStatusResolver is constructed before the evaluator workers fork, so
+   those children would inherit a FileTransfer whose worker thread no longer
+   exists.  Keep the resolver's HTTP transport private instead, leaving the
+   process-global transport uninitialised until a child needs it. */
+auto openSubstituters() -> std::list<nix::ref<nix::Store>> {
+    auto fileTransfer = nix::makeFileTransfer();
+    std::list<nix::ref<nix::Store>> stores;
+    std::set<nix::StoreReference> done;
+
+    for (const auto &storeReference :
+         nix::settings.getWorkerSettings().substituters.get()) {
+        if (!done.insert(storeReference).second) {
+            continue;
+        }
+        try {
+            auto config =
+                nix::resolveStoreConfig(nix::StoreReference{storeReference});
+            nix::ref<nix::Store> store = [&]() -> nix::ref<nix::Store> {
+                if (auto httpConfig = config.dynamic_pointer_cast<
+                                      nix::HttpBinaryCacheStoreConfig>()) {
+                    return nix::ref{httpConfig}->openStore(fileTransfer);
+                }
+                return config->openStore();
+            }();
+            store->init();
+            stores.push_back(std::move(store));
+        } catch (nix::Error &error) {
+            nix::logger->logEI(nix::lvlWarn, error.info());
+        }
+    }
+
+    stores.sort([](const nix::ref<nix::Store> &lhs,
+                   const nix::ref<nix::Store> &rhs) -> bool {
+        return lhs->config.priority < rhs->config.priority;
+    });
+    return stores;
+}
+
 /* Deterministic output order: by name, then full path (matches the
    previous queryMissing-based implementation). */
 void sortPaths(std::vector<nix::StorePath> &paths) {
@@ -45,7 +88,7 @@ void sortPaths(std::vector<nix::StorePath> &paths) {
 } // namespace
 
 CacheStatusResolver::CacheStatusResolver(nix::ref<nix::Store> store, Sink sink)
-    : store(std::move(store)), substituters(nix::getDefaultSubstituters()),
+    : store(std::move(store)), substituters(openSubstituters()),
       sink(std::move(sink)), workGuard(asio::make_work_guard(ctx)) {
     ioThread = std::thread([this]() -> void { ctx.run(); });
 }

--- a/tests-functional/test_eval.py
+++ b/tests-functional/test_eval.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
+import base64
 import contextlib
 import functools
+import hashlib
 import http.server
 import json
 import os
@@ -681,6 +683,59 @@ def _http_server(directory: Path):
     finally:
         server.shutdown()
         thread.join()
+
+
+def test_cache_status_does_not_break_fetchers_after_fork(tmp_path: Path) -> None:
+    """The cache resolver must not initialise Nix's global HTTP transport
+    before evaluator workers fork. The transport's thread does not survive the
+    fork, so a fetcher evaluated in the child would otherwise hang forever.
+    """
+    env = _hermetic_nix_env(tmp_path)
+    served = tmp_path / "served"
+    served.mkdir()
+    source = b"fetched by an evaluator worker\n"
+    served.joinpath("source").write_bytes(source)
+    served.joinpath("nix-cache-info").write_text(
+        f"StoreDir: {env['NIX_STORE_DIR']}\nWantMassQuery: 1\nPriority: 40\n"
+    )
+    digest = base64.b64encode(hashlib.sha256(source).digest()).decode()
+
+    with _http_server(served) as url:
+        expression = f'''{{
+          job = derivation {{
+            name = "fork-fetch";
+            system = builtins.currentSystem;
+            builder = "/bin/sh";
+            src = builtins.fetchurl {{
+              url = "{url}/source";
+              sha256 = "sha256-{digest}";
+            }};
+          }};
+        }}'''
+        res = subprocess.run(
+            [
+                str(BIN),
+                "--workers",
+                "1",
+                "--check-cache-status",
+                "--option",
+                "substituters",
+                url,
+                "--option",
+                "require-sigs",
+                "false",
+                "--expr",
+                expression,
+            ],
+            env=env,
+            text=True,
+            check=True,
+            capture_output=True,
+            timeout=10,
+        )
+
+    job = json.loads(res.stdout)
+    assert job["attr"] == "job"
 
 
 @pytest.mark.skipif(shutil.which("nix") is None, reason="requires nix CLI")


### PR DESCRIPTION
Use a resolver-private HTTP transport so evaluator children do not inherit Nix's process-global FileTransfer across `fork()`. Adds a regression test for `--check-cache-status` with fetcher evaluation.

Found while upgrading nix-ocaml/nix-overlays#2515.